### PR TITLE
feat: add nodeSelector to helm chart

### DIFF
--- a/helm/charts/vector-operator/templates/deployment.yaml
+++ b/helm/charts/vector-operator/templates/deployment.yaml
@@ -26,6 +26,10 @@ spec:
       labels:
         {{- include "chart.selectorLabels" . | nindent 8 }}
     spec:
+    {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+    {{- end }}
     {{- with .Values.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}

--- a/helm/charts/vector-operator/values.yaml
+++ b/helm/charts/vector-operator/values.yaml
@@ -21,6 +21,8 @@ strategy: {}
 
 imagePullSecrets: []
 
+nodeSelector: {}
+
 securityContext: {}
   # allowPrivilegeEscalation: false
   # runAsGroup: 1000


### PR DESCRIPTION
Motivation:

Ability to define nodeSelector for vector-operator deployment