### PR TITLE
Add probes attribute to vector-agent

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,7 @@
 # - use the VERSION as arg of the bundle target (e.g make bundle VERSION=0.0.2)
 # - use environment variables to overwrite this value (e.g export VERSION=0.0.2)
 VERSION ?= 0.0.1
+DOCKER_PLATFORM ?= linux/amd64
 
 # CHANNELS define the bundle channels used in the bundle.
 # Add a new line here if you would like to change its default config. (E.g CHANNELS = "candidate,fast,stable")
@@ -117,7 +118,7 @@ run: manifests generate fmt vet ## Run a controller from your host.
 
 .PHONY: docker-build
 docker-build: test ## Build docker image with the manager.
-	docker build -t ${IMG} .
+	docker build --platform ${DOCKER_PLATFORM} -t ${IMG} .
 
 .PHONY: docker-push
 docker-push: ## Push docker image with the manager.
@@ -233,4 +234,3 @@ catalog-build: opm ## Build a catalog image.
 .PHONY: catalog-push
 catalog-push: ## Push a catalog image.
 	$(MAKE) docker-push IMG=$(CATALOG_IMG)
-	

--- a/api/v1alpha1/vector_types.go
+++ b/api/v1alpha1/vector_types.go
@@ -117,6 +117,14 @@ type VectorAgent struct {
 	// +optional
 	Volumes []v1.Volume `json:"volumes,omitempty"`
 
+	// Periodic probe of container service readiness. Container will be removed from service endpoints if the probe fails.
+	// +optional
+	ReadinessProbe *v1.Probe `json:"readinessProbe,omitempty"`
+
+	// Periodic probe of container liveness. Container will be restarted if the probe fails.
+	// +optional
+	LivenessProbe *v1.Probe `json:"livenessProbe,omitempty"`
+
 	// Pod volumes to mount into the container's filesystem.
 	// +optional
 	VolumeMounts []v1.VolumeMount `json:"volumeMounts,omitempty"`
@@ -132,6 +140,10 @@ type VectorAgent struct {
 type ApiSpec struct {
 	Enabled    bool `json:"enabled,omitempty"`
 	Playground bool `json:"playground,omitempty"`
+	// Enable ReadinessProbe and LivenessProbe via api /health endpoint.
+	// If probe enabled via VectorAgent, this setting will be ignored for that probe.
+	// +optional
+	Healthcheck bool `json:"healthcheck,omitempty"`
 }
 
 // ConfigCheck is the Schema for control params for ConfigCheck pods

--- a/api/v1alpha1/zz_generated.deepcopy.go
+++ b/api/v1alpha1/zz_generated.deepcopy.go
@@ -226,6 +226,16 @@ func (in *VectorAgent) DeepCopyInto(out *VectorAgent) {
 			(*in)[i].DeepCopyInto(&(*out)[i])
 		}
 	}
+	if in.ReadinessProbe != nil {
+		in, out := &in.ReadinessProbe, &out.ReadinessProbe
+		*out = new(v1.Probe)
+		(*in).DeepCopyInto(*out)
+	}
+	if in.LivenessProbe != nil {
+		in, out := &in.LivenessProbe, &out.LivenessProbe
+		*out = new(v1.Probe)
+		(*in).DeepCopyInto(*out)
+	}
 	if in.VolumeMounts != nil {
 		in, out := &in.VolumeMounts, &out.VolumeMounts
 		*out = make([]v1.VolumeMount, len(*in))

--- a/config/crd/bases/observability.kaasops.io_vectors.yaml
+++ b/config/crd/bases/observability.kaasops.io_vectors.yaml
@@ -920,6 +920,11 @@ spec:
                     properties:
                       enabled:
                         type: boolean
+                      healthcheck:
+                        description: Enable ReadinessProbe and LivenessProbe via api
+                          /health endpoint. If probe enabled via VectorAgent, this
+                          setting will be ignored for that probe.
+                        type: boolean
                       playground:
                         type: boolean
                     type: object
@@ -2270,6 +2275,155 @@ spec:
                   internalMetrics:
                     description: Enable internal metrics exporter
                     type: boolean
+                  livenessProbe:
+                    description: Periodic probe of container liveness. Container will
+                      be restarted if the probe fails.
+                    properties:
+                      exec:
+                        description: Exec specifies the action to take.
+                        properties:
+                          command:
+                            description: Command is the command line to execute inside
+                              the container, the working directory for the command  is
+                              root ('/') in the container's filesystem. The command
+                              is simply exec'd, it is not run inside a shell, so traditional
+                              shell instructions ('|', etc) won't work. To use a shell,
+                              you need to explicitly call out to that shell. Exit
+                              status of 0 is treated as live/healthy and non-zero
+                              is unhealthy.
+                            items:
+                              type: string
+                            type: array
+                        type: object
+                      failureThreshold:
+                        description: Minimum consecutive failures for the probe to
+                          be considered failed after having succeeded. Defaults to
+                          3. Minimum value is 1.
+                        format: int32
+                        type: integer
+                      grpc:
+                        description: GRPC specifies an action involving a GRPC port.
+                          This is a beta field and requires enabling GRPCContainerProbe
+                          feature gate.
+                        properties:
+                          port:
+                            description: Port number of the gRPC service. Number must
+                              be in the range 1 to 65535.
+                            format: int32
+                            type: integer
+                          service:
+                            description: "Service is the name of the service to place
+                              in the gRPC HealthCheckRequest (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+                              \n If this is not specified, the default behavior is
+                              defined by gRPC."
+                            type: string
+                        required:
+                        - port
+                        type: object
+                      httpGet:
+                        description: HTTPGet specifies the http request to perform.
+                        properties:
+                          host:
+                            description: Host name to connect to, defaults to the
+                              pod IP. You probably want to set "Host" in httpHeaders
+                              instead.
+                            type: string
+                          httpHeaders:
+                            description: Custom headers to set in the request. HTTP
+                              allows repeated headers.
+                            items:
+                              description: HTTPHeader describes a custom header to
+                                be used in HTTP probes
+                              properties:
+                                name:
+                                  description: The header field name
+                                  type: string
+                                value:
+                                  description: The header field value
+                                  type: string
+                              required:
+                              - name
+                              - value
+                              type: object
+                            type: array
+                          path:
+                            description: Path to access on the HTTP server.
+                            type: string
+                          port:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            description: Name or number of the port to access on the
+                              container. Number must be in the range 1 to 65535. Name
+                              must be an IANA_SVC_NAME.
+                            x-kubernetes-int-or-string: true
+                          scheme:
+                            description: Scheme to use for connecting to the host.
+                              Defaults to HTTP.
+                            type: string
+                        required:
+                        - port
+                        type: object
+                      initialDelaySeconds:
+                        description: 'Number of seconds after the container has started
+                          before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                        format: int32
+                        type: integer
+                      periodSeconds:
+                        description: How often (in seconds) to perform the probe.
+                          Default to 10 seconds. Minimum value is 1.
+                        format: int32
+                        type: integer
+                      successThreshold:
+                        description: Minimum consecutive successes for the probe to
+                          be considered successful after having failed. Defaults to
+                          1. Must be 1 for liveness and startup. Minimum value is
+                          1.
+                        format: int32
+                        type: integer
+                      tcpSocket:
+                        description: TCPSocket specifies an action involving a TCP
+                          port.
+                        properties:
+                          host:
+                            description: 'Optional: Host name to connect to, defaults
+                              to the pod IP.'
+                            type: string
+                          port:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            description: Number or name of the port to access on the
+                              container. Number must be in the range 1 to 65535. Name
+                              must be an IANA_SVC_NAME.
+                            x-kubernetes-int-or-string: true
+                        required:
+                        - port
+                        type: object
+                      terminationGracePeriodSeconds:
+                        description: Optional duration in seconds the pod needs to
+                          terminate gracefully upon probe failure. The grace period
+                          is the duration in seconds after the processes running in
+                          the pod are sent a termination signal and the time when
+                          the processes are forcibly halted with a kill signal. Set
+                          this value longer than the expected cleanup time for your
+                          process. If this value is nil, the pod's terminationGracePeriodSeconds
+                          will be used. Otherwise, this value overrides the value
+                          provided by the pod spec. Value must be non-negative integer.
+                          The value zero indicates stop immediately via the kill signal
+                          (no opportunity to shut down). This is a beta field and
+                          requires enabling ProbeTerminationGracePeriod feature gate.
+                          Minimum value is 1. spec.terminationGracePeriodSeconds is
+                          used if unset.
+                        format: int64
+                        type: integer
+                      timeoutSeconds:
+                        description: 'Number of seconds after which the probe times
+                          out. Defaults to 1 second. Minimum value is 1. More info:
+                          https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                        format: int32
+                        type: integer
+                    type: object
                   podSecurityContext:
                     description: SecurityContext holds pod-level security attributes
                       and common container settings. This defaults to the default
@@ -2449,6 +2603,155 @@ spec:
                   priorityClassName:
                     description: PriorityClassName assigned to the Pods
                     type: string
+                  readinessProbe:
+                    description: Periodic probe of container service readiness. Container
+                      will be removed from service endpoints if the probe fails.
+                    properties:
+                      exec:
+                        description: Exec specifies the action to take.
+                        properties:
+                          command:
+                            description: Command is the command line to execute inside
+                              the container, the working directory for the command  is
+                              root ('/') in the container's filesystem. The command
+                              is simply exec'd, it is not run inside a shell, so traditional
+                              shell instructions ('|', etc) won't work. To use a shell,
+                              you need to explicitly call out to that shell. Exit
+                              status of 0 is treated as live/healthy and non-zero
+                              is unhealthy.
+                            items:
+                              type: string
+                            type: array
+                        type: object
+                      failureThreshold:
+                        description: Minimum consecutive failures for the probe to
+                          be considered failed after having succeeded. Defaults to
+                          3. Minimum value is 1.
+                        format: int32
+                        type: integer
+                      grpc:
+                        description: GRPC specifies an action involving a GRPC port.
+                          This is a beta field and requires enabling GRPCContainerProbe
+                          feature gate.
+                        properties:
+                          port:
+                            description: Port number of the gRPC service. Number must
+                              be in the range 1 to 65535.
+                            format: int32
+                            type: integer
+                          service:
+                            description: "Service is the name of the service to place
+                              in the gRPC HealthCheckRequest (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+                              \n If this is not specified, the default behavior is
+                              defined by gRPC."
+                            type: string
+                        required:
+                        - port
+                        type: object
+                      httpGet:
+                        description: HTTPGet specifies the http request to perform.
+                        properties:
+                          host:
+                            description: Host name to connect to, defaults to the
+                              pod IP. You probably want to set "Host" in httpHeaders
+                              instead.
+                            type: string
+                          httpHeaders:
+                            description: Custom headers to set in the request. HTTP
+                              allows repeated headers.
+                            items:
+                              description: HTTPHeader describes a custom header to
+                                be used in HTTP probes
+                              properties:
+                                name:
+                                  description: The header field name
+                                  type: string
+                                value:
+                                  description: The header field value
+                                  type: string
+                              required:
+                              - name
+                              - value
+                              type: object
+                            type: array
+                          path:
+                            description: Path to access on the HTTP server.
+                            type: string
+                          port:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            description: Name or number of the port to access on the
+                              container. Number must be in the range 1 to 65535. Name
+                              must be an IANA_SVC_NAME.
+                            x-kubernetes-int-or-string: true
+                          scheme:
+                            description: Scheme to use for connecting to the host.
+                              Defaults to HTTP.
+                            type: string
+                        required:
+                        - port
+                        type: object
+                      initialDelaySeconds:
+                        description: 'Number of seconds after the container has started
+                          before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                        format: int32
+                        type: integer
+                      periodSeconds:
+                        description: How often (in seconds) to perform the probe.
+                          Default to 10 seconds. Minimum value is 1.
+                        format: int32
+                        type: integer
+                      successThreshold:
+                        description: Minimum consecutive successes for the probe to
+                          be considered successful after having failed. Defaults to
+                          1. Must be 1 for liveness and startup. Minimum value is
+                          1.
+                        format: int32
+                        type: integer
+                      tcpSocket:
+                        description: TCPSocket specifies an action involving a TCP
+                          port.
+                        properties:
+                          host:
+                            description: 'Optional: Host name to connect to, defaults
+                              to the pod IP.'
+                            type: string
+                          port:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            description: Number or name of the port to access on the
+                              container. Number must be in the range 1 to 65535. Name
+                              must be an IANA_SVC_NAME.
+                            x-kubernetes-int-or-string: true
+                        required:
+                        - port
+                        type: object
+                      terminationGracePeriodSeconds:
+                        description: Optional duration in seconds the pod needs to
+                          terminate gracefully upon probe failure. The grace period
+                          is the duration in seconds after the processes running in
+                          the pod are sent a termination signal and the time when
+                          the processes are forcibly halted with a kill signal. Set
+                          this value longer than the expected cleanup time for your
+                          process. If this value is nil, the pod's terminationGracePeriodSeconds
+                          will be used. Otherwise, this value overrides the value
+                          provided by the pod spec. Value must be non-negative integer.
+                          The value zero indicates stop immediately via the kill signal
+                          (no opportunity to shut down). This is a beta field and
+                          requires enabling ProbeTerminationGracePeriod feature gate.
+                          Minimum value is 1. spec.terminationGracePeriodSeconds is
+                          used if unset.
+                        format: int64
+                        type: integer
+                      timeoutSeconds:
+                        description: 'Number of seconds after which the probe times
+                          out. Defaults to 1 second. Minimum value is 1. More info:
+                          https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                        format: int32
+                        type: integer
+                    type: object
                   resources:
                     description: Resources container resource request and limits,
                       https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/

--- a/controllers/factory/utils/k8s/k8s.go
+++ b/controllers/factory/utils/k8s/k8s.go
@@ -95,6 +95,7 @@ func createOrUpdateDeployment(ctx context.Context, obj runtime.Object, c client.
 		}
 
 		// Compare
+		// FIXME: DeepDerivative does not compare fields, if they omitted in desiredFields
 		if !equality.Semantic.DeepDerivative(desiredFields, existingFields) {
 			// Update if not equal
 			existing.Labels = desired.Labels
@@ -133,6 +134,7 @@ func createOrUpdateStatefulSet(ctx context.Context, obj runtime.Object, c client
 		}
 
 		// Compare
+		// FIXME: DeepDerivative does not compare fields, if they omitted in desiredFields
 		if !equality.Semantic.DeepDerivative(desiredFields, existingFields) {
 			// Update if not equal
 			existing.Labels = desired.Labels
@@ -171,6 +173,7 @@ func createOrUpdateDaemonSet(ctx context.Context, obj runtime.Object, c client.C
 		}
 
 		// Compare
+		// FIXME: DeepDerivative does not compare fields, if they omitted in desiredFields
 		if !equality.Semantic.DeepDerivative(desiredFields, existingFields) {
 			// Update if not equal
 			existing.Labels = desired.Labels
@@ -209,6 +212,7 @@ func createOrUpdateSecret(ctx context.Context, obj runtime.Object, c client.Clie
 		}
 
 		// Compare
+		// FIXME: DeepDerivative does not compare fields, if they omitted in desiredFields
 		if !equality.Semantic.DeepDerivative(desiredFields, existingFields) {
 			// Update if not equal
 			existing.Labels = desired.Labels
@@ -247,6 +251,7 @@ func createOrUpdateService(ctx context.Context, obj runtime.Object, c client.Cli
 		}
 
 		// Compare
+		// FIXME: DeepDerivative does not compare fields, if they omitted in desiredFields
 		if !equality.Semantic.DeepDerivative(desiredFields, existingFields) {
 			// Update if not equal
 			existing.Labels = desired.Labels
@@ -283,6 +288,7 @@ func createOrUpdateServiceAccount(ctx context.Context, obj runtime.Object, c cli
 		}
 
 		// Compare
+		// FIXME: DeepDerivative does not compare fields, if they omitted in desiredFields
 		if !equality.Semantic.DeepDerivative(desiredFields, existingFields) {
 			// Update if not equal
 			existing.Labels = desired.Labels
@@ -320,6 +326,7 @@ func createOrUpdateClusterRole(ctx context.Context, obj runtime.Object, c client
 		}
 
 		// Compare
+		// FIXME: DeepDerivative does not compare fields, if they omitted in desiredFields
 		if !equality.Semantic.DeepDerivative(desiredFields, existingFields) {
 			// Update if not equal
 			existing.Labels = desired.Labels
@@ -360,6 +367,7 @@ func createOrUpdateClusterRoleBinding(ctx context.Context, obj runtime.Object, c
 		}
 
 		// Compare
+		// FIXME: DeepDerivative does not compare fields, if they omitted in desiredFields
 		if !equality.Semantic.DeepDerivative(desiredFields, existingFields) {
 			// Update if not equal
 			existing.Labels = desired.Labels
@@ -401,6 +409,7 @@ func createOrUpdatePodMonitor(ctx context.Context, obj runtime.Object, c client.
 		}
 
 		// Compare
+		// FIXME: DeepDerivative does not compare fields, if they omitted in desiredFields
 		if !equality.Semantic.DeepDerivative(desiredFields, existingFields) {
 			// Update if not equal
 			existing.Labels = desired.Labels

--- a/controllers/factory/vector/vectoragent/vectoragent_daemonset.go
+++ b/controllers/factory/vector/vectoragent/vectoragent_daemonset.go
@@ -215,6 +215,8 @@ func (ctrl *Controller) VectorAgentContainer() *corev1.Container {
 			},
 		},
 		VolumeMounts:    ctrl.generateVectorAgentVolumeMounts(),
+		ReadinessProbe:  ctrl.Vector.Spec.Agent.ReadinessProbe,
+		LivenessProbe:   ctrl.Vector.Spec.Agent.LivenessProbe,
 		Resources:       ctrl.Vector.Spec.Agent.Resources,
 		SecurityContext: ctrl.Vector.Spec.Agent.ContainerSecurityContext,
 		ImagePullPolicy: ctrl.Vector.Spec.Agent.ImagePullPolicy,

--- a/controllers/factory/vector/vectoragent/vectoragent_default.go
+++ b/controllers/factory/vector/vectoragent/vectoragent_default.go
@@ -20,6 +20,7 @@ import (
 	"github.com/kaasops/vector-operator/api/v1alpha1"
 	corev1 "k8s.io/api/core/v1"
 	resourcev1 "k8s.io/apimachinery/pkg/api/resource"
+	"k8s.io/apimachinery/pkg/util/intstr"
 )
 
 func (ctrl *Controller) SetDefault() {
@@ -76,6 +77,43 @@ func (ctrl *Controller) SetDefault() {
 		}
 	}
 
+	if ctrl.Vector.Spec.Agent.ReadinessProbe == nil && ctrl.Vector.Spec.Agent.Api.Enabled && ctrl.Vector.Spec.Agent.Api.Healthcheck {
+		ctrl.Vector.Spec.Agent.ReadinessProbe = &corev1.Probe{
+			ProbeHandler: corev1.ProbeHandler{
+				HTTPGet: &corev1.HTTPGetAction{
+					Path: "/health",
+					Port: intstr.IntOrString{
+						Type:   intstr.Type(0),
+						IntVal: 8686,
+					},
+				},
+			},
+			PeriodSeconds:       20,
+			InitialDelaySeconds: 15,
+			TimeoutSeconds:      3,
+			SuccessThreshold:    0,
+			FailureThreshold:    0,
+		}
+	}
+	if ctrl.Vector.Spec.Agent.LivenessProbe == nil && ctrl.Vector.Spec.Agent.Api.Enabled && ctrl.Vector.Spec.Agent.Api.Healthcheck {
+		ctrl.Vector.Spec.Agent.LivenessProbe = &corev1.Probe{
+			ProbeHandler: corev1.ProbeHandler{
+				HTTPGet: &corev1.HTTPGetAction{
+					Path: "/health",
+					Port: intstr.IntOrString{
+						Type:   intstr.Type(0),
+						IntVal: 8686,
+					},
+				},
+			},
+			PeriodSeconds:       20,
+			InitialDelaySeconds: 15,
+			TimeoutSeconds:      3,
+			SuccessThreshold:    0,
+			FailureThreshold:    0,
+		}
+	}
+
 	if ctrl.Vector.Spec.Agent.VolumeMounts == nil {
 		ctrl.Vector.Spec.Agent.VolumeMounts = []corev1.VolumeMount{
 			{
@@ -107,4 +145,5 @@ func (ctrl *Controller) SetDefault() {
 			corev1.ResourceCPU:    resourcev1.MustParse("1000m"),
 		}
 	}
+
 }

--- a/docs/specification.md
+++ b/docs/specification.md
@@ -67,6 +67,14 @@
         <td>PodSecurityPolicyName - defines name for podSecurityPolicy in case of empty value, prefixedName will be used.</td>
     </tr>
     <tr>
+        <td>readinessProbe</td>
+        <td>Periodic probe of container service readiness. Container will be removed from service endpoints if the probe fails. By default - not set</td>
+    </tr>
+    <tr>
+        <td>livenessProbe</td>
+        <td>Periodic probe of container liveness. Container will be restarted if the probe fails. By default - not set</td>
+    </tr>
+    <tr>
         <td>volumes</td>
         <td>List of volumes that can be mounted by containers belonging to the pod.</td>
     </tr>
@@ -91,7 +99,7 @@
 ## Api Spec
 <table>
 <tr>
-      <td rowspan="4"><a href="https://vector.dev/docs/reference/api/">api</a></td>
+      <td rowspan="5"><a href="https://vector.dev/docs/reference/api/">api</a></td>
     </tr>
     <tr>
         <td>address</td>
@@ -104,6 +112,10 @@
     <tr>
         <td>playground</td>
         <td>Whether the GraphQL Playground is enabled for the API. The Playground is accessible via the /playground endpoint of the address set using the bind parameter. By default - <code>false</code></td>
+    </tr>
+    <tr>
+        <td>healthcheck</td>
+        <td>Enable ReadinessProbe and LivenessProbe via API <code>/health</code> endpoint. If probes enabled via VectorAgent, this setting will be ignored for that probe. By default - <code>false</code></td>
     </tr>
 </table>
 


### PR DESCRIPTION
- add **readinessProbe** and **livenessProbe** for Vector Agent.
- add **api.healthcheck** flag, that enable **readinessProbe** and **livenessProbe** for Vector Agent via API endpoint `/health`