### PR TITLE
Add support for global option expire_metrics_secs

### DIFF
--- a/api/v1alpha1/vector_common_types.go
+++ b/api/v1alpha1/vector_common_types.go
@@ -69,6 +69,9 @@ type VectorCommon struct {
 	// The directory used for persisting Vector state, such as on-disk buffers, file checkpoints, and more. Please make sure the Vector project has write permissions to this directory.
 	// https://vector.dev/docs/reference/configuration/global-options/#data_dir
 	DataDir string `json:"dataDir,omitempty"`
+	// Vector will expire internal metrics that haven’t been emitted/updated in the configured interval (default 300 seconds).
+	// https://vector.dev/docs/reference/configuration/global-options/#expire_metrics_secs
+	ExpireMetricsSecs int `json:expireMetricsSecs,omitempty`
 	// Vector API params. Allows to interact with a running Vector instance.
 	// https://vector.dev/docs/reference/api/
 	Api ApiSpec `json:"api,omitempty"`

--- a/api/v1alpha1/vector_common_types.go
+++ b/api/v1alpha1/vector_common_types.go
@@ -71,7 +71,7 @@ type VectorCommon struct {
 	DataDir string `json:"dataDir,omitempty"`
 	// Vector will expire internal metrics that haven’t been emitted/updated in the configured interval (default 300 seconds).
 	// https://vector.dev/docs/reference/configuration/global-options/#expire_metrics_secs
-	ExpireMetricsSecs int `json:expireMetricsSecs,omitempty`
+	ExpireMetricsSecs int `json:"expireMetricsSecs,omitempty"`
 	// Vector API params. Allows to interact with a running Vector instance.
 	// https://vector.dev/docs/reference/api/
 	Api ApiSpec `json:"api,omitempty"`

--- a/config/crd/bases/observability.kaasops.io_clustervectoraggregators.yaml
+++ b/config/crd/bases/observability.kaasops.io_clustervectoraggregators.yaml
@@ -2298,6 +2298,11 @@ spec:
                   The directory used for persisting Vector state, such as on-disk buffers, file checkpoints, and more. Please make sure the Vector project has write permissions to this directory.
                   https://vector.dev/docs/reference/configuration/global-options/#data_dir
                 type: string
+              expireMetricsSecs:
+                description: |-
+                  Vector will expire internal metrics that haven’t been emitted/updated in the configured interval (default 300 seconds).
+                  https://vector.dev/docs/reference/configuration/global-options/#expire_metrics_secs
+                type: integer
               env:
                 description: Env that will be added to Vector pod
                 items:

--- a/config/crd/bases/observability.kaasops.io_vectoraggregators.yaml
+++ b/config/crd/bases/observability.kaasops.io_vectoraggregators.yaml
@@ -2296,6 +2296,11 @@ spec:
                   The directory used for persisting Vector state, such as on-disk buffers, file checkpoints, and more. Please make sure the Vector project has write permissions to this directory.
                   https://vector.dev/docs/reference/configuration/global-options/#data_dir
                 type: string
+              expireMetricsSecs:
+                description: |-
+                  Vector will expire internal metrics that haven’t been emitted/updated in the configured interval (default 300 seconds).
+                  https://vector.dev/docs/reference/configuration/global-options/#expire_metrics_secs
+                type: integer
               env:
                 description: Env that will be added to Vector pod
                 items:

--- a/config/crd/bases/observability.kaasops.io_vectors.yaml
+++ b/config/crd/bases/observability.kaasops.io_vectors.yaml
@@ -2314,6 +2314,11 @@ spec:
                       The directory used for persisting Vector state, such as on-disk buffers, file checkpoints, and more. Please make sure the Vector project has write permissions to this directory.
                       https://vector.dev/docs/reference/configuration/global-options/#data_dir
                     type: string
+                  expireMetricsSecs:
+                    description: |-
+                      Vector will expire internal metrics that haven’t been emitted/updated in the configured interval (default 300 seconds).
+                      https://vector.dev/docs/reference/configuration/global-options/#expire_metrics_secs
+                    type: integer
                   env:
                     description: Env that will be added to Vector pod
                     items:

--- a/docs/specification.md
+++ b/docs/specification.md
@@ -19,6 +19,10 @@
         <td><a href="https://vector.dev/docs/reference/configuration/global-options/#data_dir">DataDir</a> for Vector Agent. `/vector-data-dir` by default</td>
     </tr>
     <tr>
+        <td>expireMetricsSecs</td>
+        <td><a href="https://vector.dev/docs/reference/configuration/global-options/#expire_metrics_secs">ExpireMetricsSecs</a> 300 by default</td>
+    </tr>
+    <tr>
         <td><a href="https://vector.dev/docs/reference/api/">api</a></td>
         <td><a href="https://github.com/kaasops/vector-operator/blob/main/docs/specification.md#api-spec">ApiSpec</a></td>
     </tr>

--- a/helm/charts/vector-operator/crds/observability.kaasops.io_clustervectoraggregators.yaml
+++ b/helm/charts/vector-operator/crds/observability.kaasops.io_clustervectoraggregators.yaml
@@ -2298,6 +2298,11 @@ spec:
                   The directory used for persisting Vector state, such as on-disk buffers, file checkpoints, and more. Please make sure the Vector project has write permissions to this directory.
                   https://vector.dev/docs/reference/configuration/global-options/#data_dir
                 type: string
+              expireMetricsSecs:
+                description: |-
+                  Vector will expire internal metrics that haven’t been emitted/updated in the configured interval (default 300 seconds).
+                  https://vector.dev/docs/reference/configuration/global-options/#expire_metrics_secs
+                type: integer
               env:
                 description: Env that will be added to Vector pod
                 items:

--- a/helm/charts/vector-operator/crds/observability.kaasops.io_vectoraggregators.yaml
+++ b/helm/charts/vector-operator/crds/observability.kaasops.io_vectoraggregators.yaml
@@ -2296,6 +2296,11 @@ spec:
                   The directory used for persisting Vector state, such as on-disk buffers, file checkpoints, and more. Please make sure the Vector project has write permissions to this directory.
                   https://vector.dev/docs/reference/configuration/global-options/#data_dir
                 type: string
+              expireMetricsSecs:
+                description: |-
+                  Vector will expire internal metrics that haven’t been emitted/updated in the configured interval (default 300 seconds).
+                  https://vector.dev/docs/reference/configuration/global-options/#expire_metrics_secs
+                type: integer
               env:
                 description: Env that will be added to Vector pod
                 items:

--- a/helm/charts/vector-operator/crds/observability.kaasops.io_vectors.yaml
+++ b/helm/charts/vector-operator/crds/observability.kaasops.io_vectors.yaml
@@ -2314,6 +2314,11 @@ spec:
                       The directory used for persisting Vector state, such as on-disk buffers, file checkpoints, and more. Please make sure the Vector project has write permissions to this directory.
                       https://vector.dev/docs/reference/configuration/global-options/#data_dir
                     type: string
+                  expireMetricsSecs:
+                    description: |-
+                      Vector will expire internal metrics that haven’t been emitted/updated in the configured interval (default 300 seconds).
+                      https://vector.dev/docs/reference/configuration/global-options/#expire_metrics_secs
+                    type: integer
                   env:
                     description: Env that will be added to Vector pod
                     items:

--- a/internal/config/types.go
+++ b/internal/config/types.go
@@ -18,14 +18,16 @@ package config
 
 import (
 	"fmt"
+
 	corev1 "k8s.io/api/core/v1"
 )
 
 type VectorConfig struct {
-	DataDir        string   `yaml:"data_dir"`
-	Api            *ApiSpec `yaml:"api"`
-	PipelineConfig `yaml:",inline"`
-	internal       internalConfig `yaml:"-"`
+	DataDir           string          `yaml:"data_dir"`
+	ExpireMetricsSecs int             `yaml:"expire_metrics_secs"`
+	Api               *ApiSpec        `yaml:"api"`
+	PipelineConfig                    `yaml:",inline"`
+	internal           internalConfig `yaml:"-"`
 }
 
 type PipelineConfig struct {

--- a/internal/vector/aggregator/controller.go
+++ b/internal/vector/aggregator/controller.go
@@ -2,6 +2,7 @@ package aggregator
 
 import (
 	"context"
+
 	vectorv1alpha1 "github.com/kaasops/vector-operator/api/v1alpha1"
 	"github.com/kaasops/vector-operator/internal/buildinfo"
 	"github.com/kaasops/vector-operator/internal/config"
@@ -142,6 +143,10 @@ func (ctrl *Controller) setDefault() {
 
 	if ctrl.Spec.DataDir == "" {
 		ctrl.Spec.DataDir = "/var/lib/vector"
+	}
+
+	if ctrl.Spec.ExpireMetricsSecs == 0 {
+		ctrl.Spec.ExpireMetricsSecs = 300
 	}
 
 	if ctrl.Spec.Volumes == nil {

--- a/internal/vector/vectoragent/vectoragent_default.go
+++ b/internal/vector/vectoragent/vectoragent_default.go
@@ -48,6 +48,10 @@ func (ctrl *Controller) SetDefault() {
 		ctrl.Vector.Spec.Agent.DataDir = "/var/lib/vector"
 	}
 
+	if ctrl.Vector.Spec.Agent.ExpireMetricsSecs == 0 {
+		ctrl.Vector.Spec.Agent.ExpireMetricsSecs = 300
+	}
+
 	if ctrl.Vector.Spec.Agent.Volumes == nil {
 		ctrl.Vector.Spec.Agent.Volumes = []corev1.Volume{
 			{


### PR DESCRIPTION
Add support for Vector global option [expire_metrics_secs](https://vector.dev/docs/reference/configuration/global-options/#expire_metrics_secs)
Solved the issue #165