### PR TITLE
Global options: expire_metrics_secs

### DIFF
--- a/api/v1alpha1/vector_common_types.go
+++ b/api/v1alpha1/vector_common_types.go
@@ -71,7 +71,7 @@ type VectorCommon struct {
 	DataDir string `json:"dataDir,omitempty"`
 	// Vector will expire internal metrics that haven’t been emitted/updated in the configured interval (default 300 seconds).
 	// https://vector.dev/docs/reference/configuration/global-options/#expire_metrics_secs
-	ExpireMetricsSecs int `json:"expireMetricsSecs,omitempty"`
+	ExpireMetricsSecs *int `json:"expireMetricsSecs,omitempty"`
 	// Vector API params. Allows to interact with a running Vector instance.
 	// https://vector.dev/docs/reference/api/
 	Api ApiSpec `json:"api,omitempty"`

--- a/api/v1alpha1/vector_common_types.go
+++ b/api/v1alpha1/vector_common_types.go
@@ -69,6 +69,9 @@ type VectorCommon struct {
 	// The directory used for persisting Vector state, such as on-disk buffers, file checkpoints, and more. Please make sure the Vector project has write permissions to this directory.
 	// https://vector.dev/docs/reference/configuration/global-options/#data_dir
 	DataDir string `json:"dataDir,omitempty"`
+	// Vector will expire internal metrics that haven’t been emitted/updated in the configured interval (default 300 seconds).
+	// https://vector.dev/docs/reference/configuration/global-options/#expire_metrics_secs
+	ExpireMetricsSecs int `json:"expireMetricsSecs,omitempty"`
 	// Vector API params. Allows to interact with a running Vector instance.
 	// https://vector.dev/docs/reference/api/
 	Api ApiSpec `json:"api,omitempty"`

--- a/api/v1alpha1/zz_generated.deepcopy.go
+++ b/api/v1alpha1/zz_generated.deepcopy.go
@@ -466,6 +466,11 @@ func (in *VectorCommon) DeepCopyInto(out *VectorCommon) {
 			(*in)[i].DeepCopyInto(&(*out)[i])
 		}
 	}
+	if in.ExpireMetricsSecs != nil {
+		in, out := &in.ExpireMetricsSecs, &out.ExpireMetricsSecs
+		*out = new(int)
+		**out = **in
+	}
 	out.Api = in.Api
 	if in.Volumes != nil {
 		in, out := &in.Volumes, &out.Volumes

--- a/config/crd/bases/observability.kaasops.io_clustervectoraggregators.yaml
+++ b/config/crd/bases/observability.kaasops.io_clustervectoraggregators.yaml
@@ -2298,6 +2298,11 @@ spec:
                   The directory used for persisting Vector state, such as on-disk buffers, file checkpoints, and more. Please make sure the Vector project has write permissions to this directory.
                   https://vector.dev/docs/reference/configuration/global-options/#data_dir
                 type: string
+              expireMetricsSecs:
+                description: |-
+                  Vector will expire internal metrics that haven’t been emitted/updated in the configured interval (default 300 seconds).
+                  https://vector.dev/docs/reference/configuration/global-options/#expire_metrics_secs
+                type: integer
               env:
                 description: Env that will be added to Vector pod
                 items:

--- a/config/crd/bases/observability.kaasops.io_clustervectoraggregators.yaml
+++ b/config/crd/bases/observability.kaasops.io_clustervectoraggregators.yaml
@@ -2298,11 +2298,6 @@ spec:
                   The directory used for persisting Vector state, such as on-disk buffers, file checkpoints, and more. Please make sure the Vector project has write permissions to this directory.
                   https://vector.dev/docs/reference/configuration/global-options/#data_dir
                 type: string
-              expireMetricsSecs:
-                description: |-
-                  Vector will expire internal metrics that haven’t been emitted/updated in the configured interval (default 300 seconds).
-                  https://vector.dev/docs/reference/configuration/global-options/#expire_metrics_secs
-                type: integer
               env:
                 description: Env that will be added to Vector pod
                 items:
@@ -2433,6 +2428,11 @@ spec:
                     format: int32
                     type: integer
                 type: object
+              expireMetricsSecs:
+                description: |-
+                  Vector will expire internal metrics that haven’t been emitted/updated in the configured interval (default 300 seconds).
+                  https://vector.dev/docs/reference/configuration/global-options/#expire_metrics_secs
+                type: integer
               host_aliases:
                 description: |-
                   HostAliases provides mapping between ip and hostnames,

--- a/config/crd/bases/observability.kaasops.io_vectoraggregators.yaml
+++ b/config/crd/bases/observability.kaasops.io_vectoraggregators.yaml
@@ -2296,6 +2296,11 @@ spec:
                   The directory used for persisting Vector state, such as on-disk buffers, file checkpoints, and more. Please make sure the Vector project has write permissions to this directory.
                   https://vector.dev/docs/reference/configuration/global-options/#data_dir
                 type: string
+              expireMetricsSecs:
+                description: |-
+                  Vector will expire internal metrics that haven’t been emitted/updated in the configured interval (default 300 seconds).
+                  https://vector.dev/docs/reference/configuration/global-options/#expire_metrics_secs
+                type: integer
               env:
                 description: Env that will be added to Vector pod
                 items:

--- a/config/crd/bases/observability.kaasops.io_vectoraggregators.yaml
+++ b/config/crd/bases/observability.kaasops.io_vectoraggregators.yaml
@@ -2296,11 +2296,6 @@ spec:
                   The directory used for persisting Vector state, such as on-disk buffers, file checkpoints, and more. Please make sure the Vector project has write permissions to this directory.
                   https://vector.dev/docs/reference/configuration/global-options/#data_dir
                 type: string
-              expireMetricsSecs:
-                description: |-
-                  Vector will expire internal metrics that haven’t been emitted/updated in the configured interval (default 300 seconds).
-                  https://vector.dev/docs/reference/configuration/global-options/#expire_metrics_secs
-                type: integer
               env:
                 description: Env that will be added to Vector pod
                 items:
@@ -2431,6 +2426,11 @@ spec:
                     format: int32
                     type: integer
                 type: object
+              expireMetricsSecs:
+                description: |-
+                  Vector will expire internal metrics that haven’t been emitted/updated in the configured interval (default 300 seconds).
+                  https://vector.dev/docs/reference/configuration/global-options/#expire_metrics_secs
+                type: integer
               host_aliases:
                 description: |-
                   HostAliases provides mapping between ip and hostnames,

--- a/config/crd/bases/observability.kaasops.io_vectors.yaml
+++ b/config/crd/bases/observability.kaasops.io_vectors.yaml
@@ -2314,6 +2314,11 @@ spec:
                       The directory used for persisting Vector state, such as on-disk buffers, file checkpoints, and more. Please make sure the Vector project has write permissions to this directory.
                       https://vector.dev/docs/reference/configuration/global-options/#data_dir
                     type: string
+                  expireMetricsSecs:
+                    description: |-
+                      Vector will expire internal metrics that haven’t been emitted/updated in the configured interval (default 300 seconds).
+                      https://vector.dev/docs/reference/configuration/global-options/#expire_metrics_secs
+                    type: integer
                   env:
                     description: Env that will be added to Vector pod
                     items:

--- a/config/crd/bases/observability.kaasops.io_vectors.yaml
+++ b/config/crd/bases/observability.kaasops.io_vectors.yaml
@@ -2314,11 +2314,6 @@ spec:
                       The directory used for persisting Vector state, such as on-disk buffers, file checkpoints, and more. Please make sure the Vector project has write permissions to this directory.
                       https://vector.dev/docs/reference/configuration/global-options/#data_dir
                     type: string
-                  expireMetricsSecs:
-                    description: |-
-                      Vector will expire internal metrics that haven’t been emitted/updated in the configured interval (default 300 seconds).
-                      https://vector.dev/docs/reference/configuration/global-options/#expire_metrics_secs
-                    type: integer
                   env:
                     description: Env that will be added to Vector pod
                     items:
@@ -2439,6 +2434,11 @@ spec:
                       - name
                       type: object
                     type: array
+                  expireMetricsSecs:
+                    description: |-
+                      Vector will expire internal metrics that haven’t been emitted/updated in the configured interval (default 300 seconds).
+                      https://vector.dev/docs/reference/configuration/global-options/#expire_metrics_secs
+                    type: integer
                   host_aliases:
                     description: |-
                       HostAliases provides mapping between ip and hostnames,

--- a/docs/specification.md
+++ b/docs/specification.md
@@ -19,6 +19,10 @@
         <td><a href="https://vector.dev/docs/reference/configuration/global-options/#data_dir">DataDir</a> for Vector Agent. `/vector-data-dir` by default</td>
     </tr>
     <tr>
+        <td>expireMetricsSecs</td>
+        <td><a href="https://vector.dev/docs/reference/configuration/global-options/#expire_metrics_secs">ExpireMetricsSecs</a> 300 by default</td>
+    </tr>
+    <tr>
         <td><a href="https://vector.dev/docs/reference/api/">api</a></td>
         <td><a href="https://github.com/kaasops/vector-operator/blob/main/docs/specification.md#api-spec">ApiSpec</a></td>
     </tr>

--- a/helm/charts/vector-operator/crds/observability.kaasops.io_clustervectoraggregators.yaml
+++ b/helm/charts/vector-operator/crds/observability.kaasops.io_clustervectoraggregators.yaml
@@ -2298,6 +2298,11 @@ spec:
                   The directory used for persisting Vector state, such as on-disk buffers, file checkpoints, and more. Please make sure the Vector project has write permissions to this directory.
                   https://vector.dev/docs/reference/configuration/global-options/#data_dir
                 type: string
+              expireMetricsSecs:
+                description: |-
+                  Vector will expire internal metrics that haven’t been emitted/updated in the configured interval (default 300 seconds).
+                  https://vector.dev/docs/reference/configuration/global-options/#expire_metrics_secs
+                type: integer
               env:
                 description: Env that will be added to Vector pod
                 items:

--- a/helm/charts/vector-operator/crds/observability.kaasops.io_vectoraggregators.yaml
+++ b/helm/charts/vector-operator/crds/observability.kaasops.io_vectoraggregators.yaml
@@ -2296,6 +2296,11 @@ spec:
                   The directory used for persisting Vector state, such as on-disk buffers, file checkpoints, and more. Please make sure the Vector project has write permissions to this directory.
                   https://vector.dev/docs/reference/configuration/global-options/#data_dir
                 type: string
+              expireMetricsSecs:
+                description: |-
+                  Vector will expire internal metrics that haven’t been emitted/updated in the configured interval (default 300 seconds).
+                  https://vector.dev/docs/reference/configuration/global-options/#expire_metrics_secs
+                type: integer
               env:
                 description: Env that will be added to Vector pod
                 items:

--- a/helm/charts/vector-operator/crds/observability.kaasops.io_vectors.yaml
+++ b/helm/charts/vector-operator/crds/observability.kaasops.io_vectors.yaml
@@ -2314,6 +2314,11 @@ spec:
                       The directory used for persisting Vector state, such as on-disk buffers, file checkpoints, and more. Please make sure the Vector project has write permissions to this directory.
                       https://vector.dev/docs/reference/configuration/global-options/#data_dir
                     type: string
+                  expireMetricsSecs:
+                    description: |-
+                      Vector will expire internal metrics that haven’t been emitted/updated in the configured interval (default 300 seconds).
+                      https://vector.dev/docs/reference/configuration/global-options/#expire_metrics_secs
+                    type: integer
                   env:
                     description: Env that will be added to Vector pod
                     items:

--- a/internal/common/annotations.go
+++ b/internal/common/annotations.go
@@ -2,4 +2,5 @@ package common
 
 const (
 	AnnotationServiceName = "observability.kaasops.io/service-name"
+	AnnotationRestartedAt = "vector-operator.kaasops.io/restartedAt"
 )

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -41,6 +41,7 @@ type VectorConfigParams struct {
 	PlaygroundEnabled bool
 	UseApiServerCache bool
 	InternalMetrics   bool
+	ExpireMetricsSecs *int
 }
 
 func newVectorConfig(p VectorConfigParams) *VectorConfig {
@@ -62,6 +63,7 @@ func newVectorConfig(p VectorConfigParams) *VectorConfig {
 			Transforms: transforms,
 			Sinks:      sinks,
 		},
+		ExpireMetricsSecs: p.ExpireMetricsSecs,
 	}
 }
 

--- a/internal/config/types.go
+++ b/internal/config/types.go
@@ -18,14 +18,16 @@ package config
 
 import (
 	"fmt"
+
 	corev1 "k8s.io/api/core/v1"
 )
 
 type VectorConfig struct {
-	DataDir        string   `yaml:"data_dir"`
-	Api            *ApiSpec `yaml:"api"`
-	PipelineConfig `yaml:",inline"`
-	internal       internalConfig `yaml:"-"`
+	DataDir           string          `yaml:"data_dir"`
+	ExpireMetricsSecs int             `yaml:"expire_metrics_secs"`
+	Api               *ApiSpec        `yaml:"api"`
+	PipelineConfig                    `yaml:",inline"`
+	internal           internalConfig `yaml:"-"`
 }
 
 type PipelineConfig struct {

--- a/internal/config/types.go
+++ b/internal/config/types.go
@@ -23,11 +23,11 @@ import (
 )
 
 type VectorConfig struct {
-	DataDir           string          `yaml:"data_dir"`
-	ExpireMetricsSecs int             `yaml:"expire_metrics_secs"`
-	Api               *ApiSpec        `yaml:"api"`
-	PipelineConfig                    `yaml:",inline"`
-	internal           internalConfig `yaml:"-"`
+	DataDir           string   `yaml:"data_dir"`
+	ExpireMetricsSecs *int     `yaml:"expire_metrics_secs,omitempty"`
+	Api               *ApiSpec `yaml:"api"`
+	PipelineConfig    `yaml:",inline"`
+	internal          internalConfig `yaml:"-"`
 }
 
 type PipelineConfig struct {

--- a/internal/controller/clustervectoraggregator_controller.go
+++ b/internal/controller/clustervectoraggregator_controller.go
@@ -119,6 +119,7 @@ func (r *ClusterVectorAggregatorReconciler) createOrUpdateVectorAggregator(ctx c
 		ApiEnabled:        vaCtrl.Spec.Api.Enabled,
 		PlaygroundEnabled: vaCtrl.Spec.Api.Playground,
 		InternalMetrics:   vaCtrl.Spec.InternalMetrics,
+		ExpireMetricsSecs: vaCtrl.Spec.ExpireMetricsSecs,
 	}, pipelines...)
 	if err != nil {
 		if err := vaCtrl.SetFailedStatus(ctx, err.Error()); err != nil {

--- a/internal/controller/pipeline_controller.go
+++ b/internal/controller/pipeline_controller.go
@@ -145,6 +145,7 @@ func (r *PipelineReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 					PlaygroundEnabled: vaCtrl.Vector.Spec.Agent.Api.Playground,
 					UseApiServerCache: vaCtrl.Vector.Spec.UseApiServerCache,
 					InternalMetrics:   vaCtrl.Vector.Spec.Agent.InternalMetrics,
+					ExpireMetricsSecs: vaCtrl.Vector.Spec.Agent.ExpireMetricsSecs,
 				}, pipelineCR)
 				if err != nil {
 					return fmt.Errorf("agent %s/%s build config failed: %w: %w", vector.Namespace, vector.Name, ErrBuildConfigFailed, err)
@@ -181,6 +182,7 @@ func (r *PipelineReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 						ApiEnabled:        vaCtrl.Spec.Api.Enabled,
 						PlaygroundEnabled: vaCtrl.Spec.Api.Playground,
 						InternalMetrics:   vaCtrl.Spec.InternalMetrics,
+						ExpireMetricsSecs: vaCtrl.Spec.ExpireMetricsSecs,
 					}, pipelineCR)
 					if err != nil {
 						return fmt.Errorf("aggregator %s/%s build config failed: %w: %w", vector.Namespace, vector.Name, ErrBuildConfigFailed, err)
@@ -226,6 +228,7 @@ func (r *PipelineReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 						ApiEnabled:        vaCtrl.Spec.Api.Enabled,
 						PlaygroundEnabled: vaCtrl.Spec.Api.Playground,
 						InternalMetrics:   vaCtrl.Spec.InternalMetrics,
+						ExpireMetricsSecs: vaCtrl.Spec.ExpireMetricsSecs,
 					}, pipelineCR)
 					if err != nil {
 						return fmt.Errorf("cluster aggregator %s/%s build config failed: %w: %w", vector.Namespace, vector.Name, ErrBuildConfigFailed, err)

--- a/internal/controller/vector_controller.go
+++ b/internal/controller/vector_controller.go
@@ -194,6 +194,7 @@ func (r *VectorReconciler) createOrUpdateVector(ctx context.Context, client clie
 		PlaygroundEnabled: vaCtrl.Vector.Spec.Agent.Api.Playground,
 		UseApiServerCache: vaCtrl.Vector.Spec.UseApiServerCache,
 		InternalMetrics:   vaCtrl.Vector.Spec.Agent.InternalMetrics,
+		ExpireMetricsSecs: vaCtrl.Vector.Spec.Agent.ExpireMetricsSecs,
 	}, pipelines...)
 	if err != nil {
 		if err := vaCtrl.SetFailedStatus(ctx, err.Error()); err != nil {

--- a/internal/controller/vectoraggregator_controller.go
+++ b/internal/controller/vectoraggregator_controller.go
@@ -196,6 +196,7 @@ func (r *VectorAggregatorReconciler) createOrUpdateVectorAggregator(ctx context.
 		ApiEnabled:        vaCtrl.Spec.Api.Enabled,
 		PlaygroundEnabled: vaCtrl.Spec.Api.Playground,
 		InternalMetrics:   vaCtrl.Spec.InternalMetrics,
+		ExpireMetricsSecs: vaCtrl.Spec.ExpireMetricsSecs,
 	}, pipelines...)
 	if err != nil {
 		if err := vaCtrl.SetFailedStatus(ctx, err.Error()); err != nil {

--- a/internal/utils/compression/compression.go
+++ b/internal/utils/compression/compression.go
@@ -20,3 +20,28 @@ func Compress(data []byte, log logr.Logger) []byte {
 
 	return b.Bytes()
 }
+
+func Decompress(data []byte, log logr.Logger) []byte {
+	if len(data) == 0 {
+		return []byte{}
+	}
+
+	reader := bytes.NewReader(data)
+	gz, err := gzip.NewReader(reader)
+	if err != nil {
+		log.Error(err, "Failed to create gzip reader for decompress")
+		return nil
+	}
+	defer func() {
+		if err := gz.Close(); err != nil {
+			log.Error(err, "Failed to close reader for decompress")
+		}
+	}()
+
+	var result bytes.Buffer
+	if _, err := result.ReadFrom(gz); err != nil {
+		log.Error(err, "Failed to read decompressed data")
+		return nil
+	}
+	return result.Bytes()
+}

--- a/internal/utils/compression/compression_test.go
+++ b/internal/utils/compression/compression_test.go
@@ -1,0 +1,63 @@
+package compression
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/go-logr/logr"
+	"github.com/go-logr/zapr"
+	"go.uber.org/zap"
+)
+
+type testCase struct {
+	name string
+	data []byte
+}
+
+var testCases = []testCase{
+	{
+		name: "case1",
+		data: []byte("Hello, World"),
+	},
+	{
+		name: "caseEmpty",
+		data: []byte(""),
+	},
+	{
+		name: "caseSpecialCharacters",
+		data: []byte("!@#$%^&*()"),
+	},
+}
+
+func TestCompressAndDecompress(t *testing.T) {
+	var log logr.Logger
+	zapLog, _ := zap.NewProduction()
+	defer zapLog.Sync()
+	log = zapr.NewLogger(zapLog)
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			compressed := Compress(tc.data, log)
+			decompressed := Decompress(compressed, log)
+
+			if !bytes.Equal(tc.data, decompressed) {
+				t.Errorf("Compression and Decompression failed: expected %s, got %s", tc.data, decompressed)
+			}
+		})
+	}
+}
+
+func TestDecompressInvalidInput(t *testing.T) {
+	var log logr.Logger
+	zapLog, _ := zap.NewProduction()
+	defer zapLog.Sync()
+	log = zapr.NewLogger(zapLog)
+
+	invalidCompressedData := []byte("wrong data")
+
+	decompressed := Decompress(invalidCompressedData, log)
+
+	if decompressed != nil {
+		t.Errorf("Decompression should have failed and returned nil")
+	}
+}

--- a/internal/vector/aggregator/config.go
+++ b/internal/vector/aggregator/config.go
@@ -4,18 +4,58 @@ import (
 	"context"
 	"github.com/kaasops/vector-operator/internal/utils/compression"
 	"github.com/kaasops/vector-operator/internal/utils/k8s"
+	"gopkg.in/yaml.v2"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 )
 
-func (ctrl *Controller) ensureVectorAggregatorConfig(ctx context.Context) error {
+type globalOptions struct {
+	ExpireMetricsSecs *int `yaml:"expire_metrics_secs,omitempty"`
+}
+
+func (ctrl *Controller) ensureVectorAggregatorConfig(ctx context.Context) (bool, error) {
 	log := log.FromContext(ctx).WithValues(ctrl.prefix()+"vector-aggregator-secret", ctrl.Name)
 	log.Info("start Reconcile Vector Aggregator Secret")
+
 	vectorAggregatorSecret, err := ctrl.createVectorAggregatorConfig(ctx)
 	if err != nil {
-		return err
+		return false, err
 	}
-	return k8s.CreateOrUpdateResource(ctx, vectorAggregatorSecret, ctrl.Client)
+
+	globalOptionsChanged := false
+
+	var prevSecret corev1.Secret
+	key := types.NamespacedName{Namespace: vectorAggregatorSecret.Namespace, Name: vectorAggregatorSecret.Name}
+	if err = ctrl.Get(ctx, key, &prevSecret); err == nil {
+		// check that the global settings have not been changed
+		var prevConfig globalOptions
+		data := prevSecret.Data["config.json"]
+		if ctrl.Spec.CompressConfigFile {
+			data = compression.Decompress(data, log)
+		}
+
+		err = yaml.Unmarshal(data, &prevConfig)
+		if err == nil {
+			var actualConfig globalOptions
+			err = yaml.Unmarshal(ctrl.ConfigBytes, &actualConfig)
+			if err == nil {
+				if actualConfig.ExpireMetricsSecs == nil && prevConfig.ExpireMetricsSecs != nil {
+					globalOptionsChanged = true
+				}
+				if actualConfig.ExpireMetricsSecs != nil && prevConfig.ExpireMetricsSecs == nil {
+					globalOptionsChanged = true
+				}
+				if actualConfig.ExpireMetricsSecs != nil &&
+					prevConfig.ExpireMetricsSecs != nil &&
+					*actualConfig.ExpireMetricsSecs != *prevConfig.ExpireMetricsSecs {
+					globalOptionsChanged = true
+				}
+			}
+		}
+	}
+
+	return globalOptionsChanged, k8s.CreateOrUpdateResource(ctx, vectorAggregatorSecret, ctrl.Client)
 }
 
 func (ctrl *Controller) createVectorAggregatorConfig(ctx context.Context) (*corev1.Secret, error) {

--- a/internal/vector/aggregator/controller.go
+++ b/internal/vector/aggregator/controller.go
@@ -84,7 +84,8 @@ func (ctrl *Controller) EnsureVectorAggregator(ctx context.Context) error {
 		return err
 	}
 
-	if err := ctrl.ensureVectorAggregatorConfig(ctx); err != nil {
+	globalOptsChanged, err := ctrl.ensureVectorAggregatorConfig(ctx)
+	if err != nil {
 		return err
 	}
 
@@ -102,7 +103,7 @@ func (ctrl *Controller) EnsureVectorAggregator(ctx context.Context) error {
 		}
 	}
 
-	if err := ctrl.ensureVectorAggregatorDeployment(ctx); err != nil {
+	if err := ctrl.ensureVectorAggregatorDeployment(ctx, globalOptsChanged); err != nil {
 		return err
 	}
 
@@ -143,10 +144,6 @@ func (ctrl *Controller) setDefault() {
 
 	if ctrl.Spec.DataDir == "" {
 		ctrl.Spec.DataDir = "/var/lib/vector"
-	}
-
-	if ctrl.Spec.ExpireMetricsSecs == 0 {
-		ctrl.Spec.ExpireMetricsSecs = 300
 	}
 
 	if ctrl.Spec.Volumes == nil {

--- a/internal/vector/aggregator/controller.go
+++ b/internal/vector/aggregator/controller.go
@@ -2,6 +2,7 @@ package aggregator
 
 import (
 	"context"
+
 	vectorv1alpha1 "github.com/kaasops/vector-operator/api/v1alpha1"
 	"github.com/kaasops/vector-operator/internal/buildinfo"
 	"github.com/kaasops/vector-operator/internal/config"
@@ -142,6 +143,10 @@ func (ctrl *Controller) setDefault() {
 
 	if ctrl.Spec.DataDir == "" {
 		ctrl.Spec.DataDir = "/var/lib/vector"
+	}
+
+	if ctrl.Spec.ExpireMetricsSecs == 0 {
+		ctrl.Spec.ExpireMetricsSecs = 300
 	}
 
 	if ctrl.Spec.Volumes == nil {

--- a/internal/vector/vectoragent/vectoragent_config.go
+++ b/internal/vector/vectoragent/vectoragent_config.go
@@ -28,7 +28,7 @@ func (ctrl *Controller) createVectorAgentConfig(ctx context.Context) (*corev1.Se
 	log := log.FromContext(ctx).WithValues("vector-agent-rbac", ctrl.Vector.Name)
 	labels := ctrl.labelsForVectorAgent()
 	annotations := ctrl.annotationsForVectorAgent()
-	var data []byte = ctrl.Config
+	var data = ctrl.Config
 
 	if ctrl.Vector.Spec.Agent.CompressConfigFile {
 		data = compression.Compress(ctrl.Config, log)

--- a/internal/vector/vectoragent/vectoragent_default.go
+++ b/internal/vector/vectoragent/vectoragent_default.go
@@ -48,10 +48,6 @@ func (ctrl *Controller) SetDefault() {
 		ctrl.Vector.Spec.Agent.DataDir = "/var/lib/vector"
 	}
 
-	if ctrl.Vector.Spec.Agent.ExpireMetricsSecs == 0 {
-		ctrl.Vector.Spec.Agent.ExpireMetricsSecs = 300
-	}
-
 	if ctrl.Vector.Spec.Agent.Volumes == nil {
 		ctrl.Vector.Spec.Agent.Volumes = []corev1.Volume{
 			{

--- a/internal/vector/vectoragent/vectoragent_default.go
+++ b/internal/vector/vectoragent/vectoragent_default.go
@@ -48,6 +48,10 @@ func (ctrl *Controller) SetDefault() {
 		ctrl.Vector.Spec.Agent.DataDir = "/var/lib/vector"
 	}
 
+	if ctrl.Vector.Spec.Agent.ExpireMetricsSecs == 0 {
+		ctrl.Vector.Spec.Agent.ExpireMetricsSecs = 300
+	}
+
 	if ctrl.Vector.Spec.Agent.Volumes == nil {
 		ctrl.Vector.Spec.Agent.Volumes = []corev1.Volume{
 			{


### PR DESCRIPTION
Added support for a new global option [expire_metrics_secs](https://vector.dev/docs/reference/configuration/global-options/#expire_metrics_secs)

Added automatic restart of pods when global options change.