### PR TITLE
FEATURE: Enable envFrom on agent (rebased to main)

### DIFF
--- a/api/v1alpha1/vector_common_types.go
+++ b/api/v1alpha1/vector_common_types.go
@@ -67,6 +67,8 @@ type VectorCommon struct {
 	HostNetwork bool `json:"hostNetwork,omitempty"`
 	// Env that will be added to Vector pod
 	Env []v1.EnvVar `json:"env,omitempty"`
+	// Env that will be added to Vector pod from ConfigMap or Secret sources
+	EnvFrom []v1.EnvFromSource `json:"envFrom,omitempty"`
 	// The directory used for persisting Vector state, such as on-disk buffers, file checkpoints, and more. Please make sure the Vector project has write permissions to this directory.
 	// https://vector.dev/docs/reference/configuration/global-options/#data_dir
 	DataDir string `json:"dataDir,omitempty"`

--- a/config/crd/bases/observability.kaasops.io_clustervectoraggregators.yaml
+++ b/config/crd/bases/observability.kaasops.io_clustervectoraggregators.yaml
@@ -2416,6 +2416,52 @@ spec:
                   - name
                   type: object
                 type: array
+              envFrom:
+                description: Env that will be added to Vector pod from ConfigMap or
+                  Secret sources
+                items:
+                  description: EnvFromSource represents the source of a set of ConfigMaps
+                  properties:
+                    configMapRef:
+                      description: The ConfigMap to select from
+                      properties:
+                        name:
+                          default: ""
+                          description: |-
+                            Name of the referent.
+                            This field is effectively required, but due to backwards compatibility is
+                            allowed to be empty. Instances of this type with an empty value here are
+                            almost certainly wrong.
+                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                          type: string
+                        optional:
+                          description: Specify whether the ConfigMap must be defined
+                          type: boolean
+                      type: object
+                      x-kubernetes-map-type: atomic
+                    prefix:
+                      description: An optional identifier to prepend to each key in
+                        the ConfigMap. Must be a C_IDENTIFIER.
+                      type: string
+                    secretRef:
+                      description: The Secret to select from
+                      properties:
+                        name:
+                          default: ""
+                          description: |-
+                            Name of the referent.
+                            This field is effectively required, but due to backwards compatibility is
+                            allowed to be empty. Instances of this type with an empty value here are
+                            almost certainly wrong.
+                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                          type: string
+                        optional:
+                          description: Specify whether the Secret must be defined
+                          type: boolean
+                      type: object
+                      x-kubernetes-map-type: atomic
+                  type: object
+                type: array
               eventCollector:
                 properties:
                   image:

--- a/config/crd/bases/observability.kaasops.io_vectoraggregators.yaml
+++ b/config/crd/bases/observability.kaasops.io_vectoraggregators.yaml
@@ -2414,6 +2414,52 @@ spec:
                   - name
                   type: object
                 type: array
+              envFrom:
+                description: Env that will be added to Vector pod from ConfigMap or
+                  Secret sources
+                items:
+                  description: EnvFromSource represents the source of a set of ConfigMaps
+                  properties:
+                    configMapRef:
+                      description: The ConfigMap to select from
+                      properties:
+                        name:
+                          default: ""
+                          description: |-
+                            Name of the referent.
+                            This field is effectively required, but due to backwards compatibility is
+                            allowed to be empty. Instances of this type with an empty value here are
+                            almost certainly wrong.
+                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                          type: string
+                        optional:
+                          description: Specify whether the ConfigMap must be defined
+                          type: boolean
+                      type: object
+                      x-kubernetes-map-type: atomic
+                    prefix:
+                      description: An optional identifier to prepend to each key in
+                        the ConfigMap. Must be a C_IDENTIFIER.
+                      type: string
+                    secretRef:
+                      description: The Secret to select from
+                      properties:
+                        name:
+                          default: ""
+                          description: |-
+                            Name of the referent.
+                            This field is effectively required, but due to backwards compatibility is
+                            allowed to be empty. Instances of this type with an empty value here are
+                            almost certainly wrong.
+                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                          type: string
+                        optional:
+                          description: Specify whether the Secret must be defined
+                          type: boolean
+                      type: object
+                      x-kubernetes-map-type: atomic
+                  type: object
+                type: array
               eventCollector:
                 properties:
                   image:

--- a/config/crd/bases/observability.kaasops.io_vectors.yaml
+++ b/config/crd/bases/observability.kaasops.io_vectors.yaml
@@ -2434,6 +2434,53 @@ spec:
                       - name
                       type: object
                     type: array
+                  envFrom:
+                    description: Env that will be added to Vector pod from ConfigMap
+                      or Secret sources
+                    items:
+                      description: EnvFromSource represents the source of a set of
+                        ConfigMaps
+                      properties:
+                        configMapRef:
+                          description: The ConfigMap to select from
+                          properties:
+                            name:
+                              default: ""
+                              description: |-
+                                Name of the referent.
+                                This field is effectively required, but due to backwards compatibility is
+                                allowed to be empty. Instances of this type with an empty value here are
+                                almost certainly wrong.
+                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              type: string
+                            optional:
+                              description: Specify whether the ConfigMap must be defined
+                              type: boolean
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        prefix:
+                          description: An optional identifier to prepend to each key
+                            in the ConfigMap. Must be a C_IDENTIFIER.
+                          type: string
+                        secretRef:
+                          description: The Secret to select from
+                          properties:
+                            name:
+                              default: ""
+                              description: |-
+                                Name of the referent.
+                                This field is effectively required, but due to backwards compatibility is
+                                allowed to be empty. Instances of this type with an empty value here are
+                                almost certainly wrong.
+                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              type: string
+                            optional:
+                              description: Specify whether the Secret must be defined
+                              type: boolean
+                          type: object
+                          x-kubernetes-map-type: atomic
+                      type: object
+                    type: array
                   expireMetricsSecs:
                     description: |-
                       Vector will expire internal metrics that haven’t been emitted/updated in the configured interval (default 300 seconds).

--- a/docs/specification.md
+++ b/docs/specification.md
@@ -100,7 +100,7 @@
     </tr>
     <tr>
         <td>envFrom</td>
-        <tf>envFrom that will be added to Vector pod. By default - not set</td>
+        <td>envFrom that will be added to Vector pod. By default - not set</td>
     </tr>
 </table>
 

--- a/docs/specification.md
+++ b/docs/specification.md
@@ -98,6 +98,10 @@
         <td>env</td>
         <td>Env that will be added to Vector pod. By default - not set</td>
     </tr>
+    <tr>
+        <td>envFrom</td>
+        <tf>envFrom that will be added to Vector pod. By default - not set</td>
+    </tr>
 </table>
 
 ## Api Spec

--- a/internal/vector/vectoragent/vectoragent_daemonset.go
+++ b/internal/vector/vectoragent/vectoragent_daemonset.go
@@ -202,7 +202,7 @@ func (ctrl *Controller) generateVectorAgentEnvs() []corev1.EnvVar {
 }
 
 func (ctrl *Controller) VectorAgentContainer() *corev1.Container {
-	return &corev1.Container{
+	container := &corev1.Container{
 		Name:  ctrl.getNameVectorAgent(),
 		Image: ctrl.Vector.Spec.Agent.Image,
 		Args:  []string{"--config-dir", "/etc/vector", "--watch-config"},
@@ -221,6 +221,13 @@ func (ctrl *Controller) VectorAgentContainer() *corev1.Container {
 		SecurityContext: ctrl.Vector.Spec.Agent.ContainerSecurityContext,
 		ImagePullPolicy: ctrl.Vector.Spec.Agent.ImagePullPolicy,
 	}
+
+	// Check if envFrom is provided and set it
+	if ctrl.Vector.Spec.Agent.EnvFrom != nil {
+		container.EnvFrom = ctrl.Vector.Spec.Agent.EnvFrom
+	}
+
+	return container
 }
 
 func (ctrl *Controller) ConfigReloaderInitContainer() *corev1.Container {


### PR DESCRIPTION
This PR aims to enable the use of envFrom on the Vector Agent Pods to include things like secrets for SaaS sinks.
This is a rebased PR for #133. 
