### PR TITLE
PodSecurityPolicyName is used to set PriorityClassName

### DIFF
--- a/docs/specification.md
+++ b/docs/specification.md
@@ -10,7 +10,7 @@
 # Vector Spec
 <table>
     <tr>
-      <td rowspan="25">agent</td>
+      <td rowspan="24">agent</td>
       <td>image</td>
       <td>Image for Vector agent. <code>timberio/vector:0.47.0-distroless-libc</code> by default</td>
     </tr>
@@ -65,10 +65,6 @@
     <tr>
         <td>hostAliases</td>
         <td>HostAliases provides mapping between ip and hostnames, that would be propagated to pod.</td>
-    </tr>
-    <tr>
-        <td>podSecurityPolicyName</td>
-        <td>PodSecurityPolicyName - defines name for podSecurityPolicy in case of empty value, prefixedName will be used.</td>
     </tr>
     <tr>
         <td>readinessProbe</td>

--- a/internal/vector/aggregator/deployment.go
+++ b/internal/vector/aggregator/deployment.go
@@ -58,7 +58,7 @@ func (ctrl *Controller) createVectorAggregatorDeployment() *appsv1.Deployment {
 					RuntimeClassName:   ctrl.Spec.RuntimeClassName,
 					SchedulerName:      ctrl.Spec.SchedulerName,
 					Tolerations:        ctrl.Spec.Tolerations,
-					PriorityClassName:  ctrl.Spec.PodSecurityPolicyName,
+					PriorityClassName:  ctrl.Spec.PriorityClassName,
 					HostNetwork:        ctrl.Spec.HostNetwork,
 					HostAliases:        ctrl.Spec.HostAliases,
 					InitContainers:     initContainers,

--- a/internal/vector/aggregator/event_collector.go
+++ b/internal/vector/aggregator/event_collector.go
@@ -3,6 +3,7 @@ package aggregator
 import (
 	"context"
 	"encoding/json"
+
 	"github.com/kaasops/vector-operator/internal/evcollector"
 	"github.com/kaasops/vector-operator/internal/utils/k8s"
 	appsv1 "k8s.io/api/apps/v1"
@@ -142,7 +143,7 @@ func (ctrl *Controller) createEventCollectorDeployment() *appsv1.Deployment {
 					RuntimeClassName:   ctrl.Spec.RuntimeClassName,
 					SchedulerName:      ctrl.Spec.SchedulerName,
 					Tolerations:        ctrl.Spec.Tolerations,
-					PriorityClassName:  ctrl.Spec.PodSecurityPolicyName,
+					PriorityClassName:  ctrl.Spec.PriorityClassName,
 					HostNetwork:        ctrl.Spec.HostNetwork,
 					HostAliases:        ctrl.Spec.HostAliases,
 					Containers:         containers,

--- a/internal/vector/vectoragent/vectoragent_daemonset.go
+++ b/internal/vector/vectoragent/vectoragent_daemonset.go
@@ -53,7 +53,7 @@ func (ctrl *Controller) createVectorAgentDaemonSet() *appsv1.DaemonSet {
 					RuntimeClassName:   ctrl.Vector.Spec.Agent.RuntimeClassName,
 					SchedulerName:      ctrl.Vector.Spec.Agent.SchedulerName,
 					Tolerations:        ctrl.Vector.Spec.Agent.Tolerations,
-					PriorityClassName:  ctrl.Vector.Spec.Agent.PodSecurityPolicyName,
+					PriorityClassName:  ctrl.Vector.Spec.Agent.PriorityClassName,
 					HostNetwork:        ctrl.Vector.Spec.Agent.HostNetwork,
 					HostAliases:        ctrl.Vector.Spec.Agent.HostAliases,
 					InitContainers:     initContainers,


### PR DESCRIPTION
Fixes #183

Now, the pods' priorityClassName parameter is defined using the corresponding parameter in the CR.
The use of the deprecated PodSecurityPolicyName parameter has been removed from the code. However, for now, it has been left in the CRD to allow users to perform a smooth update. In the future, the PodSecurityPolicyName parameter will be completely removed, as it has been deprecated since version k8s 1.21 and removed completely since version 1.25.
