### PR TITLE
fix(helm): use correct semver version in Chart.yaml and bump appVersion

### DIFF
--- a/helm/charts/vector-operator/Chart.yaml
+++ b/helm/charts/vector-operator/Chart.yaml
@@ -21,7 +21,7 @@ version: "0.6.1"
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "v0.3.1"
+appVersion: "v0.3.2"
 
 home: https://github.com/kaasops/vector-operator
 sources: 


### PR DESCRIPTION
Tools like [Flux](https://fluxcd.io/flux/components/helm/helmreleases/) rely on correct Semver versioning specified in the [Helm specification](https://helm.sh/docs/topics/charts/#the-chartyaml-file). Missing the _patch_ in the version denies installing the operator.