### PR TITLE
fix: reconcile aggregator PDB last to not block HPA on failure

### DIFF
--- a/api/v1alpha1/vector_common_types.go
+++ b/api/v1alpha1/vector_common_types.go
@@ -209,13 +209,15 @@ type PodDisruptionBudget struct {
 	Enabled bool `json:"enabled,omitempty"`
 
 	// MinAvailable is the number of pods that must stay available during a voluntary
-	// disruption. Set either this or MaxUnavailable, not both. When neither is set the
-	// operator defaults to MaxUnavailable of 1.
+	// disruption. Set either this or MaxUnavailable, not both; when both are set,
+	// MinAvailable takes precedence. When neither is set the operator defaults to
+	// MaxUnavailable of 1.
 	// +optional
 	MinAvailable *intstr.IntOrString `json:"minAvailable,omitempty"`
 
 	// MaxUnavailable is the number of pods that can be unavailable during a voluntary
-	// disruption. Set either this or MinAvailable, not both.
+	// disruption. Set either this or MinAvailable, not both; ignored when MinAvailable
+	// is set.
 	// +optional
 	MaxUnavailable *intstr.IntOrString `json:"maxUnavailable,omitempty"`
 

--- a/config/crd/bases/observability.kaasops.io_clustervectoraggregators.yaml
+++ b/config/crd/bases/observability.kaasops.io_clustervectoraggregators.yaml
@@ -3321,7 +3321,8 @@ spec:
                     - type: string
                     description: |-
                       MaxUnavailable is the number of pods that can be unavailable during a voluntary
-                      disruption. Set either this or MinAvailable, not both.
+                      disruption. Set either this or MinAvailable, not both; ignored when MinAvailable
+                      is set.
                     x-kubernetes-int-or-string: true
                   minAvailable:
                     anyOf:
@@ -3329,8 +3330,9 @@ spec:
                     - type: string
                     description: |-
                       MinAvailable is the number of pods that must stay available during a voluntary
-                      disruption. Set either this or MaxUnavailable, not both. When neither is set the
-                      operator defaults to MaxUnavailable of 1.
+                      disruption. Set either this or MaxUnavailable, not both; when both are set,
+                      MinAvailable takes precedence. When neither is set the operator defaults to
+                      MaxUnavailable of 1.
                     x-kubernetes-int-or-string: true
                   unhealthyPodEvictionPolicy:
                     description: |-

--- a/config/crd/bases/observability.kaasops.io_vectoraggregators.yaml
+++ b/config/crd/bases/observability.kaasops.io_vectoraggregators.yaml
@@ -3319,7 +3319,8 @@ spec:
                     - type: string
                     description: |-
                       MaxUnavailable is the number of pods that can be unavailable during a voluntary
-                      disruption. Set either this or MinAvailable, not both.
+                      disruption. Set either this or MinAvailable, not both; ignored when MinAvailable
+                      is set.
                     x-kubernetes-int-or-string: true
                   minAvailable:
                     anyOf:
@@ -3327,8 +3328,9 @@ spec:
                     - type: string
                     description: |-
                       MinAvailable is the number of pods that must stay available during a voluntary
-                      disruption. Set either this or MaxUnavailable, not both. When neither is set the
-                      operator defaults to MaxUnavailable of 1.
+                      disruption. Set either this or MaxUnavailable, not both; when both are set,
+                      MinAvailable takes precedence. When neither is set the operator defaults to
+                      MaxUnavailable of 1.
                     x-kubernetes-int-or-string: true
                   unhealthyPodEvictionPolicy:
                     description: |-

--- a/helm/charts/vector-operator/crds/observability.kaasops.io_clustervectoraggregators.yaml
+++ b/helm/charts/vector-operator/crds/observability.kaasops.io_clustervectoraggregators.yaml
@@ -3321,7 +3321,8 @@ spec:
                     - type: string
                     description: |-
                       MaxUnavailable is the number of pods that can be unavailable during a voluntary
-                      disruption. Set either this or MinAvailable, not both.
+                      disruption. Set either this or MinAvailable, not both; ignored when MinAvailable
+                      is set.
                     x-kubernetes-int-or-string: true
                   minAvailable:
                     anyOf:
@@ -3329,8 +3330,9 @@ spec:
                     - type: string
                     description: |-
                       MinAvailable is the number of pods that must stay available during a voluntary
-                      disruption. Set either this or MaxUnavailable, not both. When neither is set the
-                      operator defaults to MaxUnavailable of 1.
+                      disruption. Set either this or MaxUnavailable, not both; when both are set,
+                      MinAvailable takes precedence. When neither is set the operator defaults to
+                      MaxUnavailable of 1.
                     x-kubernetes-int-or-string: true
                   unhealthyPodEvictionPolicy:
                     description: |-

--- a/helm/charts/vector-operator/crds/observability.kaasops.io_vectoraggregators.yaml
+++ b/helm/charts/vector-operator/crds/observability.kaasops.io_vectoraggregators.yaml
@@ -3319,7 +3319,8 @@ spec:
                     - type: string
                     description: |-
                       MaxUnavailable is the number of pods that can be unavailable during a voluntary
-                      disruption. Set either this or MinAvailable, not both.
+                      disruption. Set either this or MinAvailable, not both; ignored when MinAvailable
+                      is set.
                     x-kubernetes-int-or-string: true
                   minAvailable:
                     anyOf:
@@ -3327,8 +3328,9 @@ spec:
                     - type: string
                     description: |-
                       MinAvailable is the number of pods that must stay available during a voluntary
-                      disruption. Set either this or MaxUnavailable, not both. When neither is set the
-                      operator defaults to MaxUnavailable of 1.
+                      disruption. Set either this or MaxUnavailable, not both; when both are set,
+                      MinAvailable takes precedence. When neither is set the operator defaults to
+                      MaxUnavailable of 1.
                     x-kubernetes-int-or-string: true
                   unhealthyPodEvictionPolicy:
                     description: |-

--- a/internal/config/configcheck/configcheck.go
+++ b/internal/config/configcheck/configcheck.go
@@ -44,7 +44,7 @@ type ConfigCheck struct {
 	Config []byte
 
 	Client    client.Client
-	ClientSet *kubernetes.Clientset
+	ClientSet kubernetes.Interface
 
 	Name                     string
 	Namespace                string
@@ -72,7 +72,7 @@ type ConfigCheck struct {
 func New(
 	config []byte,
 	c client.Client,
-	cs *kubernetes.Clientset,
+	cs kubernetes.Interface,
 	vc *vectorv1alpha1.VectorCommon,
 	name, namespace string,
 	timeout time.Duration,

--- a/internal/vector/aggregator/controller.go
+++ b/internal/vector/aggregator/controller.go
@@ -36,14 +36,14 @@ type Controller struct {
 	Status              *vectorv1alpha1.VectorCommonStatus
 	ConfigBytes         []byte
 	Config              *config.VectorConfig
-	ClientSet           *kubernetes.Clientset
+	ClientSet           kubernetes.Interface
 	isClusterAggregator bool
 }
 
 func NewController(
 	v Aggregator,
 	c client.Client,
-	cs *kubernetes.Clientset,
+	cs kubernetes.Interface,
 ) *Controller {
 	ctrl := &Controller{
 		Client:           c,
@@ -107,15 +107,17 @@ func (ctrl *Controller) EnsureVectorAggregator(ctx context.Context) error {
 		return err
 	}
 
-	if err := ctrl.ensureVectorAggregatorPodDisruptionBudget(ctx); err != nil {
-		return err
-	}
-
 	if err := ctrl.ensureEventCollector(ctx); err != nil {
 		return err
 	}
 
 	if err := ctrl.ensureVectorAggregatorHPA(ctx); err != nil {
+		return err
+	}
+
+	// Kept last: a rejected PodDisruptionBudget write (admission policy, quota,
+	// RBAC) must not keep the aggregator from getting its event collector and HPA.
+	if err := ctrl.ensureVectorAggregatorPodDisruptionBudget(ctx); err != nil {
 		return err
 	}
 

--- a/internal/vector/aggregator/controller_test.go
+++ b/internal/vector/aggregator/controller_test.go
@@ -1,0 +1,79 @@
+package aggregator
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	. "github.com/onsi/gomega"
+	autoscalingv2 "k8s.io/api/autoscaling/v2"
+	policyv1 "k8s.io/api/policy/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	k8sfake "k8s.io/client-go/kubernetes/fake"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/utils/ptr"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	crfake "sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
+
+	vectorv1alpha1 "github.com/kaasops/vector-operator/api/v1alpha1"
+	"github.com/kaasops/vector-operator/internal/config"
+)
+
+// newFakeClient returns a controller-runtime fake client with the schemes the
+// aggregator manages, pre-populated with the given objects.
+func newFakeClient(g *WithT, objs ...client.Object) client.Client {
+	s := runtime.NewScheme()
+	g.Expect(clientgoscheme.AddToScheme(s)).To(Succeed())
+	g.Expect(vectorv1alpha1.AddToScheme(s)).To(Succeed())
+	return crfake.NewClientBuilder().WithScheme(s).WithObjects(objs...).Build()
+}
+
+// A rejected PodDisruptionBudget write (admission policy, quota, RBAC) must not
+// keep the aggregator from getting its HPA and event collector.
+func TestEnsureVectorAggregator_PDBWriteFailureDoesNotBlockHPA(t *testing.T) {
+	g := NewWithT(t)
+
+	s := runtime.NewScheme()
+	g.Expect(clientgoscheme.AddToScheme(s)).To(Succeed())
+	g.Expect(vectorv1alpha1.AddToScheme(s)).To(Succeed())
+
+	pdbDenied := errors.New("pdb write denied")
+	cl := crfake.NewClientBuilder().WithScheme(s).WithInterceptorFuncs(interceptor.Funcs{
+		Create: func(ctx context.Context, c client.WithWatch, obj client.Object, opts ...client.CreateOption) error {
+			if _, ok := obj.(*policyv1.PodDisruptionBudget); ok {
+				return pdbDenied
+			}
+			return c.Create(ctx, obj, opts...)
+		},
+	}).Build()
+
+	va := &vectorv1alpha1.VectorAggregator{
+		ObjectMeta: metav1.ObjectMeta{Name: "va", Namespace: "default"},
+		Spec: vectorv1alpha1.VectorAggregatorSpec{
+			VectorAggregatorCommon: vectorv1alpha1.VectorAggregatorCommon{
+				Autoscaling: vectorv1alpha1.VectorAggregatorAutoscaling{
+					Enabled:     true,
+					MinReplicas: ptr.To[int32](2),
+					MaxReplicas: 3,
+				},
+				PodDisruptionBudget: vectorv1alpha1.PodDisruptionBudget{Enabled: true},
+			},
+		},
+	}
+
+	cs := k8sfake.NewSimpleClientset()
+	cs.Fake.Resources = []*metav1.APIResourceList{{GroupVersion: "monitoring.coreos.com/v1"}}
+
+	ctrl := NewController(va, cl, cs)
+	ctrl.Config = &config.VectorConfig{}
+
+	err := ctrl.EnsureVectorAggregator(context.Background())
+	g.Expect(err).To(MatchError(pdbDenied), "the PDB failure itself must still be reported")
+
+	hpa := &autoscalingv2.HorizontalPodAutoscaler{}
+	g.Expect(cl.Get(context.Background(), types.NamespacedName{Name: "va-aggregator", Namespace: "default"}, hpa)).
+		To(Succeed(), "HPA must be ensured even when the PDB write fails")
+}

--- a/internal/vector/aggregator/hpa_test.go
+++ b/internal/vector/aggregator/hpa_test.go
@@ -1,0 +1,70 @@
+package aggregator
+
+import (
+	"context"
+	"testing"
+
+	. "github.com/onsi/gomega"
+	autoscalingv2 "k8s.io/api/autoscaling/v2"
+	api_errors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/utils/ptr"
+
+	vectorv1alpha1 "github.com/kaasops/vector-operator/api/v1alpha1"
+)
+
+func TestEnsureVectorAggregatorHPA_EnabledCreates(t *testing.T) {
+	g := NewWithT(t)
+
+	ctrl := createTestController("test-aggregator", "default",
+		&vectorv1alpha1.VectorAggregatorCommon{
+			Autoscaling: vectorv1alpha1.VectorAggregatorAutoscaling{
+				Enabled:     true,
+				MinReplicas: ptr.To[int32](2),
+				MaxReplicas: 4,
+			},
+		}, false)
+	ctrl.Client = newFakeClient(g)
+
+	g.Expect(ctrl.ensureVectorAggregatorHPA(context.Background())).To(Succeed())
+
+	hpa := &autoscalingv2.HorizontalPodAutoscaler{}
+	g.Expect(ctrl.Client.Get(context.Background(),
+		types.NamespacedName{Name: "test-aggregator-aggregator", Namespace: "default"}, hpa)).To(Succeed())
+
+	g.Expect(hpa.Spec.MinReplicas).To(HaveValue(Equal(int32(2))))
+	g.Expect(hpa.Spec.MaxReplicas).To(Equal(int32(4)))
+	g.Expect(hpa.Spec.ScaleTargetRef.Kind).To(Equal("Deployment"))
+	g.Expect(hpa.Spec.ScaleTargetRef.Name).To(Equal("test-aggregator-aggregator"))
+	g.Expect(hpa.Spec.ScaleTargetRef.APIVersion).To(Equal("apps/v1"))
+}
+
+func TestEnsureVectorAggregatorHPA_DisabledRemovesExisting(t *testing.T) {
+	g := NewWithT(t)
+
+	existing := &autoscalingv2.HorizontalPodAutoscaler{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-aggregator-aggregator", Namespace: "default"},
+	}
+
+	ctrl := createTestController("test-aggregator", "default",
+		&vectorv1alpha1.VectorAggregatorCommon{}, false)
+	ctrl.Client = newFakeClient(g, existing)
+
+	g.Expect(ctrl.ensureVectorAggregatorHPA(context.Background())).To(Succeed())
+
+	hpa := &autoscalingv2.HorizontalPodAutoscaler{}
+	err := ctrl.Client.Get(context.Background(),
+		types.NamespacedName{Name: "test-aggregator-aggregator", Namespace: "default"}, hpa)
+	g.Expect(api_errors.IsNotFound(err)).To(BeTrue(), "HPA should be removed when autoscaling is disabled")
+}
+
+func TestEnsureVectorAggregatorHPA_DisabledWithoutExistingIsNoop(t *testing.T) {
+	g := NewWithT(t)
+
+	ctrl := createTestController("test-aggregator", "default",
+		&vectorv1alpha1.VectorAggregatorCommon{}, false)
+	ctrl.Client = newFakeClient(g)
+
+	g.Expect(ctrl.ensureVectorAggregatorHPA(context.Background())).To(Succeed())
+}

--- a/internal/vector/aggregator/pdb_test.go
+++ b/internal/vector/aggregator/pdb_test.go
@@ -1,10 +1,14 @@
 package aggregator
 
 import (
+	"context"
 	"testing"
 
 	. "github.com/onsi/gomega"
 	policyv1 "k8s.io/api/policy/v1"
+	api_errors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/utils/ptr"
 
@@ -93,4 +97,91 @@ func TestCreateVectorAggregatorPodDisruptionBudget_ClusterAggregator(t *testing.
 	g.Expect(*pdb.Spec.MaxUnavailable).To(Equal(intstr.FromInt32(1)))
 	g.Expect(pdb.ObjectMeta.Namespace).To(Equal("vector-system"))
 	g.Expect(pdb.Spec.Selector.MatchLabels).To(HaveKeyWithValue("app.kubernetes.io/instance", "cluster-test-aggregator"))
+}
+
+func TestEnsureVectorAggregatorPodDisruptionBudget_Gate(t *testing.T) {
+	existing := func() *policyv1.PodDisruptionBudget {
+		return &policyv1.PodDisruptionBudget{
+			ObjectMeta: metav1.ObjectMeta{Name: "test-aggregator-aggregator", Namespace: "default"},
+		}
+	}
+
+	tests := []struct {
+		name    string
+		spec    *vectorv1alpha1.VectorAggregatorCommon
+		seed    bool
+		wantPDB bool
+	}{
+		{
+			name: "disabled removes an existing budget",
+			spec: &vectorv1alpha1.VectorAggregatorCommon{
+				Replicas: ptr.To[int32](3),
+			},
+			seed:    true,
+			wantPDB: false,
+		},
+		{
+			name: "disabled without an existing budget is a no-op",
+			spec: &vectorv1alpha1.VectorAggregatorCommon{
+				Replicas: ptr.To[int32](3),
+			},
+			wantPDB: false,
+		},
+		{
+			name: "enabled with static replicas creates the budget",
+			spec: &vectorv1alpha1.VectorAggregatorCommon{
+				Replicas:            ptr.To[int32](2),
+				PodDisruptionBudget: vectorv1alpha1.PodDisruptionBudget{Enabled: true},
+			},
+			wantPDB: true,
+		},
+		{
+			name: "enabled with autoscaling uses maxReplicas",
+			spec: &vectorv1alpha1.VectorAggregatorCommon{
+				Autoscaling:         vectorv1alpha1.VectorAggregatorAutoscaling{Enabled: true, MaxReplicas: 3},
+				PodDisruptionBudget: vectorv1alpha1.PodDisruptionBudget{Enabled: true},
+			},
+			wantPDB: true,
+		},
+		{
+			name: "enabled with one effective replica removes the budget",
+			spec: &vectorv1alpha1.VectorAggregatorCommon{
+				Autoscaling:         vectorv1alpha1.VectorAggregatorAutoscaling{Enabled: true, MaxReplicas: 1},
+				PodDisruptionBudget: vectorv1alpha1.PodDisruptionBudget{Enabled: true},
+			},
+			seed:    true,
+			wantPDB: false,
+		},
+		{
+			name: "enabled with unset replicas keeps the budget absent",
+			spec: &vectorv1alpha1.VectorAggregatorCommon{
+				PodDisruptionBudget: vectorv1alpha1.PodDisruptionBudget{Enabled: true},
+			},
+			wantPDB: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+
+			ctrl := createTestController("test-aggregator", "default", tt.spec, false)
+			if tt.seed {
+				ctrl.Client = newFakeClient(g, existing())
+			} else {
+				ctrl.Client = newFakeClient(g)
+			}
+
+			g.Expect(ctrl.ensureVectorAggregatorPodDisruptionBudget(context.Background())).To(Succeed())
+
+			pdb := &policyv1.PodDisruptionBudget{}
+			err := ctrl.Client.Get(context.Background(),
+				types.NamespacedName{Name: "test-aggregator-aggregator", Namespace: "default"}, pdb)
+			if tt.wantPDB {
+				g.Expect(err).NotTo(HaveOccurred())
+			} else {
+				g.Expect(api_errors.IsNotFound(err)).To(BeTrue(), "budget should not exist")
+			}
+		})
+	}
 }


### PR DESCRIPTION
Follow-up to #229.

The PDB step ran before the event collector and HPA steps, so a rejected PDB write (admission policy, quota, RBAC) aborted the reconcile and left the aggregator without autoscaling until the write recovered. Now it runs last; the failure is still reported and retried. Verified on a live cluster with an admission policy denying PDB writes: the HPA is created while the PDB retries.

Along the way: field docs now state that `minAvailable` wins when both `minAvailable` and `maxUnavailable` are set (CRDs regenerated, helm mirrored), and unit tests for the PDB and HPA reconcile gates plus a regression test for the new ordering. To make the gates testable, `Controller.ClientSet` and `configcheck.New` take `kubernetes.Interface` now; callers are unchanged.
