### PR TITLE
fix: store config/pipeline hashes as int64 to fit the uint32 range (#232)

### DIFF
--- a/api/v1alpha1/clustervectorpipeline.go
+++ b/api/v1alpha1/clustervectorpipeline.go
@@ -37,11 +37,11 @@ func (vp *ClusterVectorPipeline) SetReason(reason *string) {
 	vp.Status.Reason = reason
 }
 
-func (vp *ClusterVectorPipeline) GetLastAppliedPipeline() *uint32 {
+func (vp *ClusterVectorPipeline) GetLastAppliedPipeline() *int64 {
 	return vp.Status.LastAppliedPipelineHash
 }
 
-func (vp *ClusterVectorPipeline) SetLastAppliedPipeline(hash *uint32) {
+func (vp *ClusterVectorPipeline) SetLastAppliedPipeline(hash *int64) {
 	vp.Status.LastAppliedPipelineHash = hash
 }
 

--- a/api/v1alpha1/vector_common_types.go
+++ b/api/v1alpha1/vector_common_types.go
@@ -8,10 +8,13 @@ import (
 )
 
 type VectorCommonStatus struct {
-	ConfigCheckResult           *bool   `json:"configCheckResult,omitempty"`
-	Reason                      *string `json:"reason,omitempty"`
-	LastAppliedConfigHash       *uint32 `json:"LastAppliedConfigHash,omitempty"`
-	LastAppliedGlobalConfigHash *uint32 `json:"LastAppliedGlobalConfigHash,omitempty"`
+	ConfigCheckResult *bool   `json:"configCheckResult,omitempty"`
+	Reason            *string `json:"reason,omitempty"`
+	// Config hashes are CRC32 (uint32) values stored as int64: a uint32 can exceed the
+	// int32 upper bound (2147483647), and an int32 status field rejects such values,
+	// wedging the reconcile loop with configCheckResult=false. See #232.
+	LastAppliedConfigHash       *int64 `json:"LastAppliedConfigHash,omitempty"`
+	LastAppliedGlobalConfigHash *int64 `json:"LastAppliedGlobalConfigHash,omitempty"`
 }
 
 type VectorCommon struct {

--- a/api/v1alpha1/vectorpipeline.go
+++ b/api/v1alpha1/vectorpipeline.go
@@ -45,11 +45,11 @@ func (vp *VectorPipeline) SetReason(reason *string) {
 	vp.Status.Reason = reason
 }
 
-func (vp *VectorPipeline) GetLastAppliedPipeline() *uint32 {
+func (vp *VectorPipeline) GetLastAppliedPipeline() *int64 {
 	return vp.Status.LastAppliedPipelineHash
 }
 
-func (vp *VectorPipeline) SetLastAppliedPipeline(hash *uint32) {
+func (vp *VectorPipeline) SetLastAppliedPipeline(hash *int64) {
 	vp.Status.LastAppliedPipelineHash = hash
 }
 

--- a/api/v1alpha1/vectorpipeline_types.go
+++ b/api/v1alpha1/vectorpipeline_types.go
@@ -36,10 +36,14 @@ type VectorPipelineSpec struct {
 
 // VectorPipelineStatus defines the observed state of VectorPipeline
 type VectorPipelineStatus struct {
-	Role                    *VectorPipelineRole `json:"role,omitempty"`
-	ConfigCheckResult       *bool               `json:"configCheckResult,omitempty"`
-	Reason                  *string             `json:"reason,omitempty"`
-	LastAppliedPipelineHash *uint32             `json:"LastAppliedPipelineHash,omitempty"`
+	Role              *VectorPipelineRole `json:"role,omitempty"`
+	ConfigCheckResult *bool               `json:"configCheckResult,omitempty"`
+	Reason            *string             `json:"reason,omitempty"`
+	// LastAppliedPipelineHash holds the CRC32 (uint32) hash of the last successfully
+	// applied pipeline config. It is stored as an int64 because a uint32 can exceed the
+	// int32 upper bound (2147483647); an int32 field would reject roughly half of all
+	// hash values and leave the pipeline stuck with configCheckResult=false. See #232.
+	LastAppliedPipelineHash *int64 `json:"LastAppliedPipelineHash,omitempty"`
 }
 
 //+kubebuilder:object:root=true

--- a/api/v1alpha1/zz_generated.deepcopy.go
+++ b/api/v1alpha1/zz_generated.deepcopy.go
@@ -618,12 +618,12 @@ func (in *VectorCommonStatus) DeepCopyInto(out *VectorCommonStatus) {
 	}
 	if in.LastAppliedConfigHash != nil {
 		in, out := &in.LastAppliedConfigHash, &out.LastAppliedConfigHash
-		*out = new(uint32)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.LastAppliedGlobalConfigHash != nil {
 		in, out := &in.LastAppliedGlobalConfigHash, &out.LastAppliedGlobalConfigHash
-		*out = new(uint32)
+		*out = new(int64)
 		**out = **in
 	}
 }
@@ -779,7 +779,7 @@ func (in *VectorPipelineStatus) DeepCopyInto(out *VectorPipelineStatus) {
 	}
 	if in.LastAppliedPipelineHash != nil {
 		in, out := &in.LastAppliedPipelineHash, &out.LastAppliedPipelineHash
-		*out = new(uint32)
+		*out = new(int64)
 		**out = **in
 	}
 }

--- a/config/crd/bases/observability.kaasops.io_clustervectoraggregators.yaml
+++ b/config/crd/bases/observability.kaasops.io_clustervectoraggregators.yaml
@@ -5681,10 +5681,14 @@ spec:
               of ClusterVectorAggregator
             properties:
               LastAppliedConfigHash:
-                format: int32
+                description: |-
+                  Config hashes are CRC32 (uint32) values stored as int64: a uint32 can exceed the
+                  int32 upper bound (2147483647), and an int32 status field rejects such values,
+                  wedging the reconcile loop with configCheckResult=false. See #232.
+                format: int64
                 type: integer
               LastAppliedGlobalConfigHash:
-                format: int32
+                format: int64
                 type: integer
               configCheckResult:
                 type: boolean

--- a/config/crd/bases/observability.kaasops.io_clustervectorpipelines.yaml
+++ b/config/crd/bases/observability.kaasops.io_clustervectorpipelines.yaml
@@ -66,7 +66,12 @@ spec:
             description: VectorPipelineStatus defines the observed state of VectorPipeline
             properties:
               LastAppliedPipelineHash:
-                format: int32
+                description: |-
+                  LastAppliedPipelineHash holds the CRC32 (uint32) hash of the last successfully
+                  applied pipeline config. It is stored as an int64 because a uint32 can exceed the
+                  int32 upper bound (2147483647); an int32 field would reject roughly half of all
+                  hash values and leave the pipeline stuck with configCheckResult=false. See #232.
+                format: int64
                 type: integer
               configCheckResult:
                 type: boolean

--- a/config/crd/bases/observability.kaasops.io_vectoraggregators.yaml
+++ b/config/crd/bases/observability.kaasops.io_vectoraggregators.yaml
@@ -5674,10 +5674,14 @@ spec:
             description: VectorAggregatorStatus defines the observed state of VectorAggregator
             properties:
               LastAppliedConfigHash:
-                format: int32
+                description: |-
+                  Config hashes are CRC32 (uint32) values stored as int64: a uint32 can exceed the
+                  int32 upper bound (2147483647), and an int32 status field rejects such values,
+                  wedging the reconcile loop with configCheckResult=false. See #232.
+                format: int64
                 type: integer
               LastAppliedGlobalConfigHash:
-                format: int32
+                format: int64
                 type: integer
               configCheckResult:
                 type: boolean

--- a/config/crd/bases/observability.kaasops.io_vectorpipelines.yaml
+++ b/config/crd/bases/observability.kaasops.io_vectorpipelines.yaml
@@ -67,7 +67,12 @@ spec:
             description: VectorPipelineStatus defines the observed state of VectorPipeline
             properties:
               LastAppliedPipelineHash:
-                format: int32
+                description: |-
+                  LastAppliedPipelineHash holds the CRC32 (uint32) hash of the last successfully
+                  applied pipeline config. It is stored as an int64 because a uint32 can exceed the
+                  int32 upper bound (2147483647); an int32 field would reject roughly half of all
+                  hash values and leave the pipeline stuck with configCheckResult=false. See #232.
+                format: int64
                 type: integer
               configCheckResult:
                 type: boolean

--- a/config/crd/bases/observability.kaasops.io_vectors.yaml
+++ b/config/crd/bases/observability.kaasops.io_vectors.yaml
@@ -5054,10 +5054,14 @@ spec:
             description: VectorStatus defines the observed state of Vector
             properties:
               LastAppliedConfigHash:
-                format: int32
+                description: |-
+                  Config hashes are CRC32 (uint32) values stored as int64: a uint32 can exceed the
+                  int32 upper bound (2147483647), and an int32 status field rejects such values,
+                  wedging the reconcile loop with configCheckResult=false. See #232.
+                format: int64
                 type: integer
               LastAppliedGlobalConfigHash:
-                format: int32
+                format: int64
                 type: integer
               configCheckResult:
                 type: boolean

--- a/helm/charts/vector-operator/crds/observability.kaasops.io_clustervectoraggregators.yaml
+++ b/helm/charts/vector-operator/crds/observability.kaasops.io_clustervectoraggregators.yaml
@@ -5681,10 +5681,14 @@ spec:
               of ClusterVectorAggregator
             properties:
               LastAppliedConfigHash:
-                format: int32
+                description: |-
+                  Config hashes are CRC32 (uint32) values stored as int64: a uint32 can exceed the
+                  int32 upper bound (2147483647), and an int32 status field rejects such values,
+                  wedging the reconcile loop with configCheckResult=false. See #232.
+                format: int64
                 type: integer
               LastAppliedGlobalConfigHash:
-                format: int32
+                format: int64
                 type: integer
               configCheckResult:
                 type: boolean

--- a/helm/charts/vector-operator/crds/observability.kaasops.io_clustervectorpipelines.yaml
+++ b/helm/charts/vector-operator/crds/observability.kaasops.io_clustervectorpipelines.yaml
@@ -66,7 +66,12 @@ spec:
             description: VectorPipelineStatus defines the observed state of VectorPipeline
             properties:
               LastAppliedPipelineHash:
-                format: int32
+                description: |-
+                  LastAppliedPipelineHash holds the CRC32 (uint32) hash of the last successfully
+                  applied pipeline config. It is stored as an int64 because a uint32 can exceed the
+                  int32 upper bound (2147483647); an int32 field would reject roughly half of all
+                  hash values and leave the pipeline stuck with configCheckResult=false. See #232.
+                format: int64
                 type: integer
               configCheckResult:
                 type: boolean

--- a/helm/charts/vector-operator/crds/observability.kaasops.io_vectoraggregators.yaml
+++ b/helm/charts/vector-operator/crds/observability.kaasops.io_vectoraggregators.yaml
@@ -5674,10 +5674,14 @@ spec:
             description: VectorAggregatorStatus defines the observed state of VectorAggregator
             properties:
               LastAppliedConfigHash:
-                format: int32
+                description: |-
+                  Config hashes are CRC32 (uint32) values stored as int64: a uint32 can exceed the
+                  int32 upper bound (2147483647), and an int32 status field rejects such values,
+                  wedging the reconcile loop with configCheckResult=false. See #232.
+                format: int64
                 type: integer
               LastAppliedGlobalConfigHash:
-                format: int32
+                format: int64
                 type: integer
               configCheckResult:
                 type: boolean

--- a/helm/charts/vector-operator/crds/observability.kaasops.io_vectorpipelines.yaml
+++ b/helm/charts/vector-operator/crds/observability.kaasops.io_vectorpipelines.yaml
@@ -67,7 +67,12 @@ spec:
             description: VectorPipelineStatus defines the observed state of VectorPipeline
             properties:
               LastAppliedPipelineHash:
-                format: int32
+                description: |-
+                  LastAppliedPipelineHash holds the CRC32 (uint32) hash of the last successfully
+                  applied pipeline config. It is stored as an int64 because a uint32 can exceed the
+                  int32 upper bound (2147483647); an int32 field would reject roughly half of all
+                  hash values and leave the pipeline stuck with configCheckResult=false. See #232.
+                format: int64
                 type: integer
               configCheckResult:
                 type: boolean

--- a/helm/charts/vector-operator/crds/observability.kaasops.io_vectors.yaml
+++ b/helm/charts/vector-operator/crds/observability.kaasops.io_vectors.yaml
@@ -5054,10 +5054,14 @@ spec:
             description: VectorStatus defines the observed state of Vector
             properties:
               LastAppliedConfigHash:
-                format: int32
+                description: |-
+                  Config hashes are CRC32 (uint32) values stored as int64: a uint32 can exceed the
+                  int32 upper bound (2147483647), and an int32 status field rejects such values,
+                  wedging the reconcile loop with configCheckResult=false. See #232.
+                format: int64
                 type: integer
               LastAppliedGlobalConfigHash:
-                format: int32
+                format: int64
                 type: integer
               configCheckResult:
                 type: boolean

--- a/internal/config/types.go
+++ b/internal/config/types.go
@@ -112,8 +112,9 @@ func (c *VectorConfig) OptimizationSummary() (sources, groups int) {
 	return c.internal.optimizedSources, c.internal.sourceGroups
 }
 
-func (c *VectorConfig) GetGlobalConfigHash() *uint32 {
+func (c *VectorConfig) GetGlobalConfigHash() *int64 {
 	bytes, _ := json.Marshal(c.globalOptions)
-	gHash := hash.Get(bytes)
+	// Widen the uint32 CRC32 to int64 so it always fits the int64 status schema. See #232.
+	gHash := int64(hash.Get(bytes))
 	return &gHash
 }

--- a/internal/controller/clustervectoraggregator_controller.go
+++ b/internal/controller/clustervectoraggregator_controller.go
@@ -138,7 +138,7 @@ func (r *ClusterVectorAggregatorReconciler) createOrUpdateVectorAggregator(ctx c
 	if err != nil {
 		return ctrl.Result{}, err
 	}
-	cfgHash := hash.Get(byteCfg)
+	cfgHash := int64(hash.Get(byteCfg))
 
 	if !vaCtrl.Spec.ConfigCheck.Disabled {
 		if vaCtrl.Status.LastAppliedConfigHash == nil || *vaCtrl.Status.LastAppliedConfigHash != cfgHash {

--- a/internal/controller/vector_controller.go
+++ b/internal/controller/vector_controller.go
@@ -222,7 +222,7 @@ func (r *VectorReconciler) createOrUpdateVector(ctx context.Context, client clie
 		log.Info("Sources optimization collapsed kubernetes_logs sources", "sources", collapsed, "optimizedSources", groups)
 	}
 
-	cfgHash := hash.Get(byteConfig)
+	cfgHash := int64(hash.Get(byteConfig))
 
 	if !vaCtrl.Vector.Spec.Agent.ConfigCheck.Disabled {
 		if vaCtrl.Vector.Status.LastAppliedConfigHash == nil || *vaCtrl.Vector.Status.LastAppliedConfigHash != cfgHash {

--- a/internal/controller/vectoraggregator_controller.go
+++ b/internal/controller/vectoraggregator_controller.go
@@ -216,7 +216,7 @@ func (r *VectorAggregatorReconciler) createOrUpdateVectorAggregator(ctx context.
 	if err != nil {
 		return ctrl.Result{}, err
 	}
-	cfgHash := hash.Get(byteCfg)
+	cfgHash := int64(hash.Get(byteCfg))
 
 	if !vaCtrl.Spec.ConfigCheck.Disabled {
 		if vaCtrl.Status.LastAppliedConfigHash == nil || *vaCtrl.Status.LastAppliedConfigHash != cfgHash {

--- a/internal/pipeline/hash.go
+++ b/internal/pipeline/hash.go
@@ -32,7 +32,7 @@ type tmp struct {
 	ConfigOptimization string `json:",omitempty"`
 }
 
-func GetPipelineHash(pipeline Pipeline) (*uint32, error) {
+func GetPipelineHash(pipeline Pipeline) (*int64, error) {
 	a, err := json.Marshal(tmp{
 		Spec:               pipeline.GetSpec(),
 		Labels:             pipeline.GetLabels(),
@@ -42,8 +42,11 @@ func GetPipelineHash(pipeline Pipeline) (*uint32, error) {
 	if err != nil {
 		return nil, err
 	}
-	hash := hash.Get(a)
-	return &hash, nil
+	// hash.Get returns a uint32 (CRC32); widen to int64 so the value always fits the
+	// status field's int32->int64 schema. A plain int32 cast would overflow to a
+	// negative number for hashes above 2147483647. See #232.
+	h := int64(hash.Get(a))
+	return &h, nil
 }
 
 // IsPipelineChanged returns true, if hash in .status.lastAppliedPipelineHash matches with spec Hash

--- a/internal/pipeline/hash_test.go
+++ b/internal/pipeline/hash_test.go
@@ -18,6 +18,7 @@ package pipeline
 
 import (
 	"encoding/json"
+	"math"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -29,6 +30,26 @@ import (
 	"github.com/kaasops/vector-operator/internal/common"
 	"github.com/kaasops/vector-operator/internal/utils/hash"
 )
+
+// Regression for #232: the CRC32 config hash is a uint32 and routinely exceeds the
+// int32 ceiling (2147483647). The status field must be a signed 64-bit int so such a
+// value is stored verbatim; a uint32->int32 schema (or cast) rejects it at the
+// apiserver and wedges the reconcile loop with configCheckResult=false forever.
+func TestLastAppliedPipelineHashHoldsFullUint32Range(t *testing.T) {
+	// crc32("test") == 3632233996, which is > math.MaxInt32 — the exact class of value
+	// that used to be rejected.
+	raw := hash.Get([]byte("test"))
+	require.Greater(t, raw, uint32(math.MaxInt32), "test input must hash above int32 max")
+
+	stored := int64(raw)
+	vp := &v1alpha1.VectorPipeline{}
+	vp.SetLastAppliedPipeline(&stored)
+
+	require.NotNil(t, vp.GetLastAppliedPipeline())
+	assert.Equal(t, int64(raw), *vp.GetLastAppliedPipeline())
+	assert.Positive(t, *vp.GetLastAppliedPipeline(), "hash must not overflow into a negative value")
+	assert.LessOrEqual(t, *vp.GetLastAppliedPipeline(), int64(math.MaxUint32))
+}
 
 // Toggling the per-pipeline config-optimization opt-out annotation must change the
 // pipeline hash so the reconcile propagates it to an agent config rebuild.
@@ -82,7 +103,7 @@ func TestGetPipelineHashStableWithoutAnnotation(t *testing.T) {
 		ServiceName string
 	}{Spec: p.Spec})
 	require.NoError(t, err)
-	assert.Equal(t, hash.Get(legacy), *h)
+	assert.Equal(t, int64(hash.Get(legacy)), *h)
 }
 
 // Toggling the annotation must read as "changed" (IsPipelineChanged == false) so the

--- a/internal/pipeline/pipeline.go
+++ b/internal/pipeline/pipeline.go
@@ -33,8 +33,8 @@ type Pipeline interface {
 	GetSpec() v1alpha1.VectorPipelineSpec
 	SetConfigCheck(bool)
 	SetReason(*string)
-	GetLastAppliedPipeline() *uint32
-	SetLastAppliedPipeline(*uint32)
+	GetLastAppliedPipeline() *int64
+	SetLastAppliedPipeline(*int64)
 	GetConfigCheckResult() *bool
 	IsValid() bool
 	IsDeleted() bool

--- a/internal/vector/aggregator/controller.go
+++ b/internal/vector/aggregator/controller.go
@@ -264,7 +264,7 @@ func (ctrl *Controller) setDefault() {
 	}
 }
 
-func (ctrl *Controller) SetSuccessStatus(ctx context.Context, hash, globCfgHash *uint32) error {
+func (ctrl *Controller) SetSuccessStatus(ctx context.Context, hash, globCfgHash *int64) error {
 	var status = true
 	ctrl.Status.ConfigCheckResult = &status
 	ctrl.Status.Reason = nil

--- a/internal/vector/vectoragent/vectoragent.go
+++ b/internal/vector/vectoragent/vectoragent.go
@@ -59,7 +59,7 @@ func NewController(v *vectorv1alpha1.Vector, c client.Client, cs *kubernetes.Cli
 	return ctrl
 }
 
-func (ctrl *Controller) SetSuccessStatus(ctx context.Context, cfgHash, globCfgHash *uint32) error {
+func (ctrl *Controller) SetSuccessStatus(ctx context.Context, cfgHash, globCfgHash *int64) error {
 	var status = true
 	ctrl.Vector.Status.ConfigCheckResult = &status
 	ctrl.Vector.Status.Reason = nil


### PR DESCRIPTION
## Summary

Fixes #232.

`ClusterVectorPipeline` (and, as it turns out, the `Vector`/`VectorAggregator`/`ClusterVectorAggregator` resources) can get permanently stuck with `configCheckResult: false` even though the config check succeeds, with the operator log looping on:

```
status: Invalid value: "": Checked value must be of type integer with format int32 in LastAppliedPipelineHash
```

## Root cause

The config/pipeline hash is a **CRC32 checksum** — a `uint32` in the range `0..4294967295` (`internal/utils/hash`). It is stored in the status as a Go `*uint32`, which makes `controller-gen` emit `format: int32` in the CRD schema.

`int32` maxes out at `2147483647`, so **any hash above that ceiling — roughly half of all values — is rejected by the API server** on the status update. The update fails on every reconcile, the resource never reaches `VALID: true`, and the reconcile loop retries forever. The `Invalid value: ""` wording is just how the apiserver's int32 range validator reports an out-of-range integer.

This is not specific to `ClusterVectorPipeline` — the namespaced `VectorPipeline` only *appeared* unaffected because its hash happened to fall below the int32 ceiling. The same defect exists in `VectorCommonStatus.LastAppliedConfigHash` / `LastAppliedGlobalConfigHash`, which back the Vector agent and aggregator CRDs.

## Reproduction

On a kind cluster (k8s v1.36), with the unpatched CRD:

```
# hash below int32 max — accepted
kubectl patch clustervectorpipeline x --subresource=status --type=merge \
  -p '{"status":{"LastAppliedPipelineHash":12345}}'          # patched

# crc32("test") = 3632233996, above int32 max — rejected
kubectl patch clustervectorpipeline x --subresource=status --type=merge \
  -p '{"status":{"LastAppliedPipelineHash":3632233996}}'
# The ClusterVectorPipeline "x" is invalid: status: Invalid value: "":
# Checked value must be of type integer with format int32 in LastAppliedPipelineHash
```

## Fix

Store the hashes as `int64`, which fully contains the `uint32` range:

- `VectorPipelineStatus.LastAppliedPipelineHash`
- `VectorCommonStatus.LastAppliedConfigHash`
- `VectorCommonStatus.LastAppliedGlobalConfigHash`

`GetPipelineHash` / `GetGlobalConfigHash` and the controllers now widen the `uint32` CRC32 to `int64` (`int64(hash.Get(...))`), so the value is always non-negative and never overflows. `int64` is backward compatible with the int32-range values already persisted in existing resources' status.

CRDs regenerated with `controller-gen v0.16.1`; the helm-chart CRD copies under `helm/charts/vector-operator/crds` were synced to match.

## Testing

- `go build ./...`, `go vet`, `gofmt` clean.
- `go test ./internal/pipeline/... ./internal/utils/hash/...` pass, including a new regression test (`TestLastAppliedPipelineHashHoldsFullUint32Range`) asserting a `uint32` above the int32 ceiling round-trips through the status field without overflow.
- Verified end-to-end on kind with the **regenerated** CRD: the status schema is now `format: int64`, and status updates with `3632233996` and `4294967295` (max uint32) are accepted, with `configCheckResult: true` persisting.
