### PR TITLE
fix: reconcile ClusterVectorAggregator only on generation changes

### DIFF
--- a/internal/controller/clustervectoraggregator_controller.go
+++ b/internal/controller/clustervectoraggregator_controller.go
@@ -30,10 +30,12 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
 	"sigs.k8s.io/controller-runtime/pkg/source"
 
 	"github.com/kaasops/vector-operator/internal/config"
@@ -187,7 +189,7 @@ func (r *ClusterVectorAggregatorReconciler) SetupWithManager(mgr ctrl.Manager) e
 	}
 
 	builder := ctrl.NewControllerManagedBy(mgr).
-		For(&v1alpha1.ClusterVectorAggregator{}).
+		For(&v1alpha1.ClusterVectorAggregator{}, builder.WithPredicates(predicate.GenerationChangedPredicate{})).
 		WatchesRawSource(source.Channel(r.EventChan, &handler.EnqueueRequestForObject{})).
 		Owns(&appsv1.Deployment{}).
 		Owns(&corev1.Service{}).

--- a/internal/controller/clustervectoraggregator_controller_test.go
+++ b/internal/controller/clustervectoraggregator_controller_test.go
@@ -18,8 +18,11 @@ package controller
 
 import (
 	"context"
+	"time"
 
+	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/event"
+	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -84,6 +87,84 @@ var _ = Describe("ClusterVectorAggregator Controller", func() {
 			Expect(err).NotTo(HaveOccurred())
 			// TODO(user): Add more specific assertions depending on your controller's reconciliation logic.
 			// Example: If you expect a certain status condition after reconciliation, verify it here.
+		})
+	})
+
+	Context("When running under a manager", func() {
+		const resourceName = "cva-predicate"
+
+		namespacedName := types.NamespacedName{Name: resourceName}
+
+		// A status-only update must not retrigger the reconcile: without the
+		// generation predicate the controller's own Status().Update feeds back
+		// into it and CVAs reconcile in a hot conflict loop.
+		It("does not reconcile on status-only updates", func() {
+			mgr, err := ctrl.NewManager(cfg, ctrl.Options{
+				Scheme:  k8sClient.Scheme(),
+				Metrics: metricsserver.Options{BindAddress: "0"},
+			})
+			Expect(err).NotTo(HaveOccurred())
+
+			reconciler := &ClusterVectorAggregatorReconciler{
+				Client:             mgr.GetClient(),
+				Scheme:             mgr.GetScheme(),
+				EventChan:          make(chan event.GenericEvent, 10),
+				ConfigCheckTimeout: configCheckTimeout,
+				Clientset:          clientset,
+			}
+			Expect(reconciler.SetupWithManager(mgr)).To(Succeed())
+
+			mgrCtx, mgrCancel := context.WithCancel(ctx)
+			defer mgrCancel()
+			go func() {
+				defer GinkgoRecover()
+				Expect(mgr.Start(mgrCtx)).To(Succeed())
+			}()
+
+			resource := &observabilityv1alpha1.ClusterVectorAggregator{
+				ObjectMeta: metav1.ObjectMeta{Name: resourceName},
+				Spec: observabilityv1alpha1.ClusterVectorAggregatorSpec{
+					ResourceNamespace: "default",
+					VectorAggregatorCommon: observabilityv1alpha1.VectorAggregatorCommon{
+						VectorCommon: observabilityv1alpha1.VectorCommon{
+							ConfigCheck: observabilityv1alpha1.ConfigCheck{Disabled: true},
+						},
+					},
+				},
+			}
+			Expect(k8sClient.Create(ctx, resource)).To(Succeed())
+			defer func() {
+				Expect(k8sClient.Delete(ctx, resource)).To(Succeed())
+			}()
+
+			By("waiting for the first reconcile to write status")
+			Eventually(func(g Gomega) {
+				g.Expect(k8sClient.Get(ctx, namespacedName, resource)).To(Succeed())
+				g.Expect(resource.Status.ConfigCheckResult).NotTo(BeNil())
+			}, "10s", "250ms").Should(Succeed())
+
+			By("waiting for the create-time reconcile chain to settle")
+			Eventually(func(g Gomega) {
+				before := &observabilityv1alpha1.ClusterVectorAggregator{}
+				g.Expect(k8sClient.Get(ctx, namespacedName, before)).To(Succeed())
+				time.Sleep(time.Second)
+				after := &observabilityv1alpha1.ClusterVectorAggregator{}
+				g.Expect(k8sClient.Get(ctx, namespacedName, after)).To(Succeed())
+				g.Expect(after.ResourceVersion).To(Equal(before.ResourceVersion))
+				resource = after
+			}, "20s", "100ms").Should(Succeed())
+
+			By("touching only the status")
+			touch := "external-status-touch"
+			resource.Status.Reason = &touch
+			Expect(k8sClient.Status().Update(ctx, resource)).To(Succeed())
+
+			By("verifying the touch is not reverted by a reconcile echo")
+			Consistently(func(g Gomega) {
+				got := &observabilityv1alpha1.ClusterVectorAggregator{}
+				g.Expect(k8sClient.Get(ctx, namespacedName, got)).To(Succeed())
+				g.Expect(got.Status.Reason).To(HaveValue(Equal(touch)))
+			}, "4s", "500ms").Should(Succeed())
 		})
 	})
 })


### PR DESCRIPTION
Add the same GenerationChangedPredicate the VectorAggregator controller already uses, so a CVA no longer reconciles itself in a loop on its own status updates.