### PR TITLE
style: resolve staticcheck ST/QF findings across the codebase

### DIFF
--- a/api/v1alpha1/vectoraggregator_types.go
+++ b/api/v1alpha1/vectoraggregator_types.go
@@ -62,7 +62,7 @@ func init() {
 }
 
 func (v *VectorAggregator) IsBeingDeleted() bool {
-	return !v.ObjectMeta.DeletionTimestamp.IsZero()
+	return !v.DeletionTimestamp.IsZero()
 }
 
 func (v *VectorAggregator) HasFinalizer(finalizerName string) bool {

--- a/internal/config/configcheck/configcheck.go
+++ b/internal/config/configcheck/configcheck.go
@@ -159,7 +159,7 @@ func (cc *ConfigCheck) Run(ctx context.Context) (string, error) {
 
 	reason, err := cc.getCheckResult(ctx, vectorConfigCheckPod)
 	if err != nil {
-		if errors.Is(err, ValidationError) {
+		if errors.Is(err, ErrValidation) {
 			return reason, err
 		}
 		return "", err
@@ -256,7 +256,7 @@ func (cc *ConfigCheck) getCheckResult(ctx context.Context, pod *corev1.Pod) (rea
 					if err != nil {
 						return "", err
 					}
-					return reason, ValidationError
+					return reason, ErrValidation
 				}
 			}
 			// Reset timer after processing event to restart timeout window
@@ -270,7 +270,7 @@ func (cc *ConfigCheck) getCheckResult(ctx context.Context, pod *corev1.Pod) (rea
 		case <-ctx.Done():
 			return "", nil
 		case <-timer.C:
-			return "", ConfigcheckTimeoutError
+			return "", ErrConfigcheckTimeout
 		}
 	}
 }

--- a/internal/config/configcheck/configcheck_error.go
+++ b/internal/config/configcheck/configcheck_error.go
@@ -21,6 +21,6 @@ import (
 )
 
 var (
-	ValidationError         = errors.New("config validation error")
-	ConfigcheckTimeoutError = errors.New("timeout waiting configcheck pod result")
+	ErrValidation         = errors.New("config validation error")
+	ErrConfigcheckTimeout = errors.New("timeout waiting configcheck pod result")
 )

--- a/internal/controller/clustervectoraggregator_controller.go
+++ b/internal/controller/clustervectoraggregator_controller.go
@@ -153,7 +153,7 @@ func (r *ClusterVectorAggregatorReconciler) createOrUpdateVectorAggregator(ctx c
 				configcheck.ConfigCheckInitiatorVector,
 			).Run(ctx)
 			if err != nil {
-				if errors.Is(err, configcheck.ValidationError) {
+				if errors.Is(err, configcheck.ErrValidation) {
 					if err := vaCtrl.SetFailedStatus(ctx, reason); err != nil {
 						return ctrl.Result{}, err
 					}

--- a/internal/controller/suite_test.go
+++ b/internal/controller/suite_test.go
@@ -38,7 +38,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 
 	"github.com/kaasops/vector-operator/api/v1alpha1"
-	observabilityv1alpha1 "github.com/kaasops/vector-operator/api/v1alpha1"
 	// +kubebuilder:scaffold:imports
 )
 
@@ -86,9 +85,6 @@ var _ = BeforeSuite(func() {
 	Expect(cfg).NotTo(BeNil())
 
 	err = v1alpha1.AddToScheme(scheme.Scheme)
-	Expect(err).NotTo(HaveOccurred())
-
-	err = observabilityv1alpha1.AddToScheme(scheme.Scheme)
 	Expect(err).NotTo(HaveOccurred())
 
 	// +kubebuilder:scaffold:scheme

--- a/internal/controller/vector_controller.go
+++ b/internal/controller/vector_controller.go
@@ -238,7 +238,7 @@ func (r *VectorReconciler) createOrUpdateVector(ctx context.Context, client clie
 			)
 			reason, err := configCheck.Run(ctx)
 			if err != nil {
-				if errors.Is(err, configcheck.ValidationError) {
+				if errors.Is(err, configcheck.ErrValidation) {
 					if err := vaCtrl.SetFailedStatus(ctx, reason); err != nil {
 						return ctrl.Result{}, err
 					}

--- a/internal/controller/vectoraggregator_controller.go
+++ b/internal/controller/vectoraggregator_controller.go
@@ -231,7 +231,7 @@ func (r *VectorAggregatorReconciler) createOrUpdateVectorAggregator(ctx context.
 				configcheck.ConfigCheckInitiatorVector,
 			).Run(ctx)
 			if err != nil {
-				if errors.Is(err, configcheck.ValidationError) {
+				if errors.Is(err, configcheck.ErrValidation) {
 					if err := vaCtrl.SetFailedStatus(ctx, reason); err != nil {
 						return ctrl.Result{}, err
 					}

--- a/internal/vector/aggregator/controller_test.go
+++ b/internal/vector/aggregator/controller_test.go
@@ -65,7 +65,7 @@ func TestEnsureVectorAggregator_PDBWriteFailureDoesNotBlockHPA(t *testing.T) {
 	}
 
 	cs := k8sfake.NewSimpleClientset()
-	cs.Fake.Resources = []*metav1.APIResourceList{{GroupVersion: "monitoring.coreos.com/v1"}}
+	cs.Resources = []*metav1.APIResourceList{{GroupVersion: "monitoring.coreos.com/v1"}}
 
 	ctrl := NewController(va, cl, cs)
 	ctrl.Config = &config.VectorConfig{}

--- a/internal/vector/aggregator/event_collector.go
+++ b/internal/vector/aggregator/event_collector.go
@@ -96,7 +96,7 @@ func (ctrl *Controller) createEventCollectorService() *corev1.Service {
 			Selector: labels,
 		},
 	}
-	svc.ObjectMeta.Name = ctrl.Name + "-event-collector"
+	svc.Name = ctrl.Name + "-event-collector"
 	return svc
 }
 
@@ -114,7 +114,7 @@ func (ctrl *Controller) createEventCollectorConfig(params *evcollector.Config) (
 		ObjectMeta: ctrl.objectMetaVectorAggregator(labels, annotations, ctrl.Namespace),
 		Data:       config,
 	}
-	cfg.ObjectMeta.Name = ctrl.Name + "-event-collector"
+	cfg.Name = ctrl.Name + "-event-collector"
 	return cfg, nil
 }
 
@@ -152,7 +152,7 @@ func (ctrl *Controller) createEventCollectorDeployment() *appsv1.Deployment {
 			},
 		},
 	}
-	deployment.ObjectMeta.Name = ctrl.Name + "-event-collector"
+	deployment.Name = ctrl.Name + "-event-collector"
 	return deployment
 }
 
@@ -231,7 +231,7 @@ func (ctrl *Controller) createEventCollectorClusterRole() *rbacv1.ClusterRole {
 		},
 	}
 
-	clusterRole.ObjectMeta.Name = ctrl.Name + "-event-collector"
+	clusterRole.Name = ctrl.Name + "-event-collector"
 	return clusterRole
 }
 
@@ -243,7 +243,7 @@ func (ctrl *Controller) createEventCollectorServiceAccount() *corev1.ServiceAcco
 		ObjectMeta: ctrl.objectMetaVectorAggregator(labels, annotations, ctrl.Namespace),
 	}
 
-	serviceAccount.ObjectMeta.Name = ctrl.Name + "-event-collector"
+	serviceAccount.Name = ctrl.Name + "-event-collector"
 
 	return serviceAccount
 }
@@ -267,7 +267,7 @@ func (ctrl *Controller) createEventCollectorClusterRoleBinding() *rbacv1.Cluster
 			},
 		},
 	}
-	clusterRoleBinding.ObjectMeta.Name = ctrl.Name + "-event-collector"
+	clusterRoleBinding.Name = ctrl.Name + "-event-collector"
 	return clusterRoleBinding
 }
 

--- a/internal/vector/aggregator/hpa_test.go
+++ b/internal/vector/aggregator/hpa_test.go
@@ -30,7 +30,7 @@ func TestEnsureVectorAggregatorHPA_EnabledCreates(t *testing.T) {
 	g.Expect(ctrl.ensureVectorAggregatorHPA(context.Background())).To(Succeed())
 
 	hpa := &autoscalingv2.HorizontalPodAutoscaler{}
-	g.Expect(ctrl.Client.Get(context.Background(),
+	g.Expect(ctrl.Get(context.Background(),
 		types.NamespacedName{Name: "test-aggregator-aggregator", Namespace: "default"}, hpa)).To(Succeed())
 
 	g.Expect(hpa.Spec.MinReplicas).To(HaveValue(Equal(int32(2))))
@@ -54,7 +54,7 @@ func TestEnsureVectorAggregatorHPA_DisabledRemovesExisting(t *testing.T) {
 	g.Expect(ctrl.ensureVectorAggregatorHPA(context.Background())).To(Succeed())
 
 	hpa := &autoscalingv2.HorizontalPodAutoscaler{}
-	err := ctrl.Client.Get(context.Background(),
+	err := ctrl.Get(context.Background(),
 		types.NamespacedName{Name: "test-aggregator-aggregator", Namespace: "default"}, hpa)
 	g.Expect(api_errors.IsNotFound(err)).To(BeTrue(), "HPA should be removed when autoscaling is disabled")
 }

--- a/internal/vector/aggregator/pdb.go
+++ b/internal/vector/aggregator/pdb.go
@@ -31,7 +31,7 @@ func (ctrl *Controller) ensureVectorAggregatorPodDisruptionBudget(ctx context.Co
 	if !ctrl.Spec.PodDisruptionBudget.Enabled || maxReplicas <= 1 {
 		log.Info("skip Reconcile Vector Aggregator PodDisruptionBudget, disabled or effective replicas <= 1")
 		pdb := ctrl.createVectorAggregatorPodDisruptionBudget()
-		if err := ctrl.Client.Delete(ctx, pdb); err != nil && !api_errors.IsNotFound(err) {
+		if err := ctrl.Delete(ctx, pdb); err != nil && !api_errors.IsNotFound(err) {
 			return err
 		}
 		return nil

--- a/internal/vector/aggregator/pdb_test.go
+++ b/internal/vector/aggregator/pdb_test.go
@@ -37,8 +37,8 @@ func TestCreateVectorAggregatorPodDisruptionBudget_Defaults(t *testing.T) {
 	g.Expect(*pdb.Spec.UnhealthyPodEvictionPolicy).To(Equal(policyv1.AlwaysAllow))
 
 	// Name and namespace track the aggregator Deployment.
-	g.Expect(pdb.ObjectMeta.Name).To(Equal("test-aggregator-aggregator"))
-	g.Expect(pdb.ObjectMeta.Namespace).To(Equal("default"))
+	g.Expect(pdb.Name).To(Equal("test-aggregator-aggregator"))
+	g.Expect(pdb.Namespace).To(Equal("default"))
 }
 
 func TestCreateVectorAggregatorPodDisruptionBudget_Configured(t *testing.T) {
@@ -95,7 +95,7 @@ func TestCreateVectorAggregatorPodDisruptionBudget_ClusterAggregator(t *testing.
 
 	g.Expect(pdb).NotTo(BeNil())
 	g.Expect(*pdb.Spec.MaxUnavailable).To(Equal(intstr.FromInt32(1)))
-	g.Expect(pdb.ObjectMeta.Namespace).To(Equal("vector-system"))
+	g.Expect(pdb.Namespace).To(Equal("vector-system"))
 	g.Expect(pdb.Spec.Selector.MatchLabels).To(HaveKeyWithValue("app.kubernetes.io/instance", "cluster-test-aggregator"))
 }
 
@@ -175,7 +175,7 @@ func TestEnsureVectorAggregatorPodDisruptionBudget_Gate(t *testing.T) {
 			g.Expect(ctrl.ensureVectorAggregatorPodDisruptionBudget(context.Background())).To(Succeed())
 
 			pdb := &policyv1.PodDisruptionBudget{}
-			err := ctrl.Client.Get(context.Background(),
+			err := ctrl.Get(context.Background(),
 				types.NamespacedName{Name: "test-aggregator-aggregator", Namespace: "default"}, pdb)
 			if tt.wantPDB {
 				g.Expect(err).NotTo(HaveOccurred())

--- a/internal/vector/aggregator/rbac.go
+++ b/internal/vector/aggregator/rbac.go
@@ -94,9 +94,9 @@ func (ctrl *Controller) createVectorAggregatorClusterRoleBinding() *rbacv1.Clust
 }
 
 func (ctrl *Controller) deleteVectorAggregatorClusterRole(ctx context.Context) error {
-	return ctrl.Client.Delete(ctx, ctrl.createVectorAggregatorClusterRole())
+	return ctrl.Delete(ctx, ctrl.createVectorAggregatorClusterRole())
 }
 
 func (ctrl *Controller) deleteVectorAggregatorClusterRoleBinding(ctx context.Context) error {
-	return ctrl.Client.Delete(ctx, ctrl.createVectorAggregatorClusterRoleBinding())
+	return ctrl.Delete(ctx, ctrl.createVectorAggregatorClusterRoleBinding())
 }

--- a/internal/vector/aggregator/service.go
+++ b/internal/vector/aggregator/service.go
@@ -32,7 +32,7 @@ func (ctrl *Controller) ensureVectorAggregatorService(ctx context.Context) error
 		}
 	}
 	for _, svc := range existing {
-		if err := ctrl.Client.Delete(ctx, svc); err != nil {
+		if err := ctrl.Delete(ctx, svc); err != nil {
 			return err
 		}
 	}
@@ -69,7 +69,7 @@ func (ctrl *Controller) createVectorAggregatorServices() ([]*corev1.Service, err
 				Selector: matchLabels,
 			},
 		}
-		svc.ObjectMeta.Name = group.ServiceName
+		svc.Name = group.ServiceName
 		svcList = append(svcList, svc)
 	}
 
@@ -99,7 +99,7 @@ func (ctrl *Controller) getExistingServices(ctx context.Context) (map[string]*co
 		Namespace:     ctrl.Namespace,
 		LabelSelector: labels.Set(ctrl.matchLabelsForVectorAggregator()).AsSelector(),
 	}
-	err := ctrl.Client.List(ctx, &svcList, opts)
+	err := ctrl.List(ctx, &svcList, opts)
 	if err != nil {
 		return nil, err
 	}

--- a/test/e2e/framework/artifacts/collector.go
+++ b/test/e2e/framework/artifacts/collector.go
@@ -24,7 +24,7 @@ import (
 	"strings"
 	"time"
 
-	. "github.com/onsi/ginkgo/v2" //nolint:golint,revive
+	. "github.com/onsi/ginkgo/v2" //nolint:golint,revive,staticcheck
 
 	"github.com/kaasops/vector-operator/test/e2e/framework/kubectl"
 )

--- a/test/e2e/framework/framework.go
+++ b/test/e2e/framework/framework.go
@@ -29,9 +29,9 @@ import (
 	"sync"
 	"time"
 
-	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/ginkgo/v2" //nolint:golint,revive,staticcheck
 	"github.com/onsi/ginkgo/v2/types"
-	. "github.com/onsi/gomega"
+	. "github.com/onsi/gomega" //nolint:golint,revive,staticcheck
 	"k8s.io/apimachinery/pkg/util/wait"
 
 	"github.com/kaasops/vector-operator/test/e2e/framework/config"

--- a/test/e2e/framework/kubectl/wait.go
+++ b/test/e2e/framework/kubectl/wait.go
@@ -22,7 +22,7 @@ import (
 	"strings"
 	"time"
 
-	. "github.com/onsi/gomega"
+	. "github.com/onsi/gomega" //nolint:golint,revive,staticcheck
 
 	"github.com/kaasops/vector-operator/test/e2e/framework/config"
 	"github.com/kaasops/vector-operator/test/utils"

--- a/test/e2e/framework/lifecycle.go
+++ b/test/e2e/framework/lifecycle.go
@@ -19,7 +19,7 @@ package framework
 import (
 	"time"
 
-	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/ginkgo/v2" //nolint:golint,revive,staticcheck
 
 	"github.com/kaasops/vector-operator/test/utils"
 )

--- a/test/e2e/framework/recorder/recorder.go
+++ b/test/e2e/framework/recorder/recorder.go
@@ -76,9 +76,9 @@ func (r *TestRecorder) ExportAsShellScript() string {
 	// Script header
 	sb.WriteString("#!/bin/bash\n")
 	sb.WriteString("# E2E Test Playbook\n")
-	sb.WriteString(fmt.Sprintf("# Test: %s\n", r.testName))
-	sb.WriteString(fmt.Sprintf("# Namespace: %s\n", r.namespace))
-	sb.WriteString(fmt.Sprintf("# Generated: %s\n\n", time.Now().Format(time.RFC3339)))
+	fmt.Fprintf(&sb, "# Test: %s\n", r.testName)
+	fmt.Fprintf(&sb, "# Namespace: %s\n", r.namespace)
+	fmt.Fprintf(&sb, "# Generated: %s\n\n", time.Now().Format(time.RFC3339))
 
 	// Shell settings for safety
 	sb.WriteString("set -e  # Exit on error\n")
@@ -86,7 +86,7 @@ func (r *TestRecorder) ExportAsShellScript() string {
 	sb.WriteString("set -o pipefail  # Catch errors in pipes\n\n")
 
 	// Variables
-	sb.WriteString(fmt.Sprintf("NAMESPACE='%s'\n", r.namespace))
+	fmt.Fprintf(&sb, "NAMESPACE='%s'\n", r.namespace)
 	sb.WriteString("KUBECTL='kubectl'\n")
 	sb.WriteString("TMPDIR=$(mktemp -d)\n")
 	sb.WriteString("trap 'rm -rf $TMPDIR' EXIT\n\n")
@@ -97,19 +97,19 @@ func (r *TestRecorder) ExportAsShellScript() string {
 	// Main steps
 	sb.WriteString("# Test Steps\n")
 	sb.WriteString("echo '═══════════════════════════════════════════════════════════'\n")
-	sb.WriteString(fmt.Sprintf("echo 'Test: %s'\n", r.testName))
+	fmt.Fprintf(&sb, "echo 'Test: %s'\n", r.testName)
 	sb.WriteString("echo '═══════════════════════════════════════════════════════════'\n\n")
 
 	for _, step := range r.steps {
-		sb.WriteString(fmt.Sprintf("# Step %d: %s\n", step.Order, step.Description))
+		fmt.Fprintf(&sb, "# Step %d: %s\n", step.Order, step.Description)
 		sb.WriteString("echo '───────────────────────────────────────────────────────────'\n")
-		sb.WriteString(fmt.Sprintf("log_info 'Step %d: %s'\n", step.Order, step.Description))
+		fmt.Fprintf(&sb, "log_info 'Step %d: %s'\n", step.Order, step.Description)
 		sb.WriteString("echo '───────────────────────────────────────────────────────────'\n")
 
 		// If there's input data, save it to a temporary file
 		if step.Input != "" {
 			tmpFile := fmt.Sprintf("$TMPDIR/step-%d.yaml", step.Order)
-			sb.WriteString(fmt.Sprintf("cat <<'EOF' > %s\n", tmpFile))
+			fmt.Fprintf(&sb, "cat <<'EOF' > %s\n", tmpFile)
 			sb.WriteString(step.Input)
 			sb.WriteString("\nEOF\n")
 
@@ -126,12 +126,12 @@ func (r *TestRecorder) ExportAsShellScript() string {
 
 		// Add expected result as comment
 		if step.Expected != "" {
-			sb.WriteString(fmt.Sprintf("# Expected: %s\n", step.Expected))
+			fmt.Fprintf(&sb, "# Expected: %s\n", step.Expected)
 		}
 
 		// Add wait condition if specified
 		if step.WaitFor != "" {
-			sb.WriteString(fmt.Sprintf("# Wait for: %s (timeout: %s)\n", step.WaitFor, step.Timeout))
+			fmt.Fprintf(&sb, "# Wait for: %s (timeout: %s)\n", step.WaitFor, step.Timeout)
 		}
 
 		sb.WriteString("\n")
@@ -150,9 +150,9 @@ func (r *TestRecorder) ExportAsMarkdown() string {
 	var sb strings.Builder
 
 	// Document header
-	sb.WriteString(fmt.Sprintf("# Test Plan: %s\n\n", r.testName))
-	sb.WriteString(fmt.Sprintf("**Generated**: %s\n\n", time.Now().Format(time.RFC3339)))
-	sb.WriteString(fmt.Sprintf("**Namespace**: `%s`\n\n", r.namespace))
+	fmt.Fprintf(&sb, "# Test Plan: %s\n\n", r.testName)
+	fmt.Fprintf(&sb, "**Generated**: %s\n\n", time.Now().Format(time.RFC3339))
+	fmt.Fprintf(&sb, "**Namespace**: `%s`\n\n", r.namespace)
 
 	// Prerequisites
 	sb.WriteString("## Prerequisites\n\n")
@@ -164,7 +164,7 @@ func (r *TestRecorder) ExportAsMarkdown() string {
 	sb.WriteString("## Test Steps\n\n")
 
 	for _, step := range r.steps {
-		sb.WriteString(fmt.Sprintf("### Step %d: %s\n\n", step.Order, step.Description))
+		fmt.Fprintf(&sb, "### Step %d: %s\n\n", step.Order, step.Description)
 
 		// Command
 		sb.WriteString("**Command**:\n")
@@ -182,15 +182,15 @@ func (r *TestRecorder) ExportAsMarkdown() string {
 
 		// Wait condition if present
 		if step.WaitFor != "" {
-			sb.WriteString(fmt.Sprintf("**Wait Condition**: `%s`\n\n", step.WaitFor))
+			fmt.Fprintf(&sb, "**Wait Condition**: `%s`\n\n", step.WaitFor)
 			if step.Timeout != "" {
-				sb.WriteString(fmt.Sprintf("**Timeout**: %s\n\n", step.Timeout))
+				fmt.Fprintf(&sb, "**Timeout**: %s\n\n", step.Timeout)
 			}
 		}
 
 		// Expected result
 		if step.Expected != "" {
-			sb.WriteString(fmt.Sprintf("**Expected Result**: %s\n\n", step.Expected))
+			fmt.Fprintf(&sb, "**Expected Result**: %s\n\n", step.Expected)
 		}
 
 		sb.WriteString("---\n\n")

--- a/test/utils/utils.go
+++ b/test/utils/utils.go
@@ -22,7 +22,7 @@ import (
 	"os/exec"
 	"strings"
 
-	. "github.com/onsi/ginkgo/v2" //nolint:golint,revive
+	. "github.com/onsi/ginkgo/v2" //nolint:golint,revive,staticcheck
 )
 
 const (
@@ -135,6 +135,6 @@ func GetProjectDir() (string, error) {
 	if err != nil {
 		return wd, err
 	}
-	wd = strings.Replace(wd, "/test/e2e", "", -1)
+	wd = strings.ReplaceAll(wd, "/test/e2e", "")
 	return wd, nil
 }


### PR DESCRIPTION
## What

Pure code-hygiene change: resolve the `stylecheck` (ST) and `quickfix` (QF)
findings that recent `staticcheck` reports by default. **No behavioural
change** — only redundant selectors, string-building, error-var naming and a
duplicate import are cleaned up.

| Check | Fix | Files |
|---|---|---|
| QF1008 | drop embedded-field selectors (`.Client`, `.ObjectMeta`, `.Fake`) | aggregator `service.go`, `rbac.go`, `pdb.go`, `event_collector.go`, `*_test.go`, `api/.../vectoraggregator_types.go` |
| QF1012 | `fmt.Fprintf(&sb, …)` instead of `sb.WriteString(fmt.Sprintf(…))` | `test/e2e/framework/recorder/recorder.go` |
| QF1004 | `strings.ReplaceAll` instead of `strings.Replace(…, -1)` | `test/utils/utils.go` |
| ST1001 | annotate the required ginkgo/gomega dot-imports with `//nolint` | `test/e2e/framework/*`, `test/utils/utils.go` |
| ST1012 | rename error vars to `ErrFoo` (`ValidationError → ErrValidation`, `ConfigcheckTimeoutError → ErrConfigcheckTimeout`) | `internal/config/configcheck/*` + call sites |
| ST1019 | drop the duplicate `api/v1alpha1` import + redundant `AddToScheme` | `internal/controller/suite_test.go` |

## Relationship to the dependency bump PR

This is intentionally split from the dependency-bump PR #235 so the two can be
**reviewed and merged independently, in any order**:

- This PR touches **only `.go` files**; it does **not** touch `go.mod`,
  `.golangci.yml`, the `Makefile` or the CI workflows.
- Its file set is **disjoint** from PR #235's — there are no overlapping
  hunks, so neither PR conflicts with the other regardless of merge order.
- These are all dependency-agnostic Go improvements; they pass under the
  current linter as well as the newer `staticcheck` shipped with
  golangci-lint v2.

Once **both** land, the temporary `staticcheck: [SA, S]` scope pin added by the
bump PR can be dropped in a trivial follow-up and these ST/QF checks become
enforced with a clean tree.

## Proofs

Verified against the branch in a `golang:1.22` container (matching the repo's
current `go.mod` / CI toolchain):

**Unit + envtest suites pass:**
```
ok  github.com/kaasops/vector-operator/cmd/checkpoint_merger          coverage: 63.2%
ok  github.com/kaasops/vector-operator/internal/checkpoint            coverage: 87.2%
ok  github.com/kaasops/vector-operator/internal/config               coverage:  9.7%
ok  github.com/kaasops/vector-operator/internal/config/configcheck   coverage:  0.8%
ok  github.com/kaasops/vector-operator/internal/controller           coverage:  6.2%   (envtest)
ok  github.com/kaasops/vector-operator/internal/pipeline             coverage:  3.1%
ok  github.com/kaasops/vector-operator/internal/utils/hash           coverage:100.0%
ok  github.com/kaasops/vector-operator/internal/utils/k8s            coverage: 65.2%
ok  github.com/kaasops/vector-operator/internal/vector/aggregator    coverage: 14.0%
ok  github.com/kaasops/vector-operator/internal/vector/vectoragent   coverage:  6.7%
```

**`gofmt` clean and `golangci-lint` (repo config) passes:**
```
$ gofmt -l internal api test cmd    # (empty)
$ make lint
golangci-lint run                   # exit 0
```
