### PR TITLE
test: run e2e on a k8s version matrix and fix same-tag reruns

### DIFF
--- a/.github/workflows/e2e-tests.yaml
+++ b/.github/workflows/e2e-tests.yaml
@@ -13,9 +13,19 @@ on:
 
 jobs:
   e2e-tests:
-    name: Run E2E Tests
+    name: Run E2E Tests (${{ matrix.k8s }})
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    strategy:
+      # Node images are digest-pinned from the kind release notes;
+      # `kind load` requires kind v0.32+ for the 1.36 images.
+      fail-fast: false
+      matrix:
+        include:
+          - k8s: v1.32.11
+            node_image: kindest/node:v1.32.11@sha256:5fc52d52a7b9574015299724bd68f183702956aa4a2116ae75a63cb574b35af8
+          - k8s: v1.36.1
+            node_image: kindest/node:v1.36.1@sha256:3489c7674813ba5d8b1a9977baea8a6e553784dab7b84759d1014dbd78f7ebd5
 
     steps:
       - name: Checkout code
@@ -27,16 +37,12 @@ jobs:
           go-version-file: 'go.mod'
           cache: true
 
-      - name: Install dependencies
-        run: |
-          # Install kubebuilder for CRD generation
-          curl -L -o kubebuilder https://go.kubebuilder.io/dl/latest/$(go env GOOS)/$(go env GOARCH)
-          chmod +x kubebuilder && sudo mv kubebuilder /usr/local/bin/
-
       - name: Create kind cluster
         uses: helm/kind-action@v1
         with:
+          version: v0.32.0
           cluster_name: kind
+          node_image: ${{ matrix.node_image }}
           config: scripts/kind-config-ci.yaml
           wait: 300s
 
@@ -45,14 +51,6 @@ jobs:
           kubectl cluster-info
           kubectl get nodes
           kubectl get pods -A
-
-      - name: Build operator image
-        run: |
-          docker build -t example.com/vector-operator:v0.0.1 .
-
-      - name: Load image into kind
-        run: |
-          kind load docker-image example.com/vector-operator:v0.0.1 --name kind
 
       - name: Run E2E tests
         run: make test-e2e
@@ -63,7 +61,7 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: e2e-results-${{ github.run_number }}
+          name: e2e-results-${{ github.run_number }}-${{ matrix.k8s }}
           path: test/e2e/results/
           retention-days: 7
 
@@ -72,5 +70,5 @@ jobs:
         uses: EnricoMi/publish-unit-test-result-action@v2
         with:
           files: test/e2e/results/run-*/reports/junit-report.xml
-          check_name: E2E Test Results
+          check_name: E2E Test Results (${{ matrix.k8s }})
           comment_mode: off

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ IMG ?= controller:latest
 IMG_COLLECTOR ?= collector:latest
 IMG_MERGER ?= checkpoint-merger:latest
 # ENVTEST_K8S_VERSION refers to the version of kubebuilder assets to be downloaded by envtest binary.
-ENVTEST_K8S_VERSION = 1.33.0
+ENVTEST_K8S_VERSION = 1.36.2
 
 # Get the currently used golang install path (in GOPATH/bin, unless GOBIN is set)
 ifeq (,$(shell go env GOBIN))
@@ -138,6 +138,14 @@ deploy-helm-e2e: manifests ## Deploy operator using Helm for e2e tests (use IMG 
 		--set image.repository=$$(echo $(IMG) | cut -d: -f1) \
 		--set image.tag=$$(echo $(IMG) | cut -d: -f2) \
 		--wait --timeout 5m
+	@echo "==> Restarting operator to pick up a freshly loaded image (same-tag reruns)..."
+	$(KUBECTL) -n $(NAMESPACE) rollout restart deployment -l app.kubernetes.io/name=vector-operator
+	$(KUBECTL) -n $(NAMESPACE) rollout status deployment -l app.kubernetes.io/name=vector-operator --timeout=120s
+	@echo "==> Waiting for the replaced operator pod to terminate..."
+	@for i in $$(seq 1 60); do \
+		[ -z "$$($(KUBECTL) -n $(NAMESPACE) get pods -l app.kubernetes.io/name=vector-operator -o jsonpath='{.items[?(@.metadata.deletionTimestamp)].metadata.name}')" ] && exit 0; \
+		sleep 2; \
+	done; echo "terminating operator pod did not go away in time" >&2; exit 1
 
 .PHONY: lint
 lint: golangci-lint ## Run golangci-lint linter

--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -19,6 +19,7 @@ package e2e
 import (
 	"context"
 	"fmt"
+	"os"
 	"os/exec"
 	"strings"
 	"testing"
@@ -38,6 +39,15 @@ const (
 	mergerImage       = "example.com/checkpoint-merger:v0.0.1"
 )
 
+// kindCluster is the kind cluster the suite loads images into.
+// Override with KIND_CLUSTER to run against a differently named cluster.
+var kindCluster = func() string {
+	if name := os.Getenv("KIND_CLUSTER"); name != "" {
+		return name
+	}
+	return "kind"
+}()
+
 // artifactCollector manages artifact collection for failed tests
 var artifactCollector artifacts.Collector
 
@@ -56,11 +66,11 @@ var _ = SynchronizedBeforeSuite(func() []byte {
 	_, err := utils.Run(cmd)
 	Expect(err).NotTo(HaveOccurred())
 
-	cmd = exec.Command("kind", "load", "docker-image", operatorImage, "--name", "kind")
+	cmd = exec.Command("kind", "load", "docker-image", operatorImage, "--name", kindCluster)
 	_, err = utils.Run(cmd)
 	Expect(err).NotTo(HaveOccurred())
 
-	cmd = exec.Command("kind", "load", "docker-image", mergerImage, "--name", "kind")
+	cmd = exec.Command("kind", "load", "docker-image", mergerImage, "--name", kindCluster)
 	_, err = utils.Run(cmd)
 	Expect(err).NotTo(HaveOccurred())
 


### PR DESCRIPTION
Run e2e on kind v1.32.11 and v1.36.1, add a `KIND_CLUSTER` override, restart the operator on deploy, bump envtest to 1.36.2.