### PR TITLE
chore(lint): enable full staticcheck (drop SA/S scope pin)

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -2,14 +2,6 @@ version: "2"
 run:
   modules-download-mode: readonly
 linters:
-  settings:
-    staticcheck:
-      # Preserve the original lint scope: v1 ran the SA (staticcheck) and S
-      # (gosimple) checks only. v2 merged stylecheck (ST) and quickfix (QF)
-      # into staticcheck and enables them by default; keep them off.
-      checks:
-        - SA
-        - S
   exclusions:
     generated: lax
     presets:

--- a/api/v1alpha1/groupversion_info.go
+++ b/api/v1alpha1/groupversion_info.go
@@ -28,7 +28,10 @@ var (
 	// GroupVersion is group version used to register these objects
 	GroupVersion = schema.GroupVersion{Group: "observability.kaasops.io", Version: "v1alpha1"}
 
-	// SchemeBuilder is used to add go types to the GroupVersionKind scheme
+	// SchemeBuilder is used to add go types to the GroupVersionKind scheme.
+	// scheme.Builder is deprecated upstream but remains the kubebuilder v4
+	// scaffold and is what the generated per-type init()s register against.
+	//nolint:staticcheck // SA1019: kubebuilder scaffold, intentional
 	SchemeBuilder = &scheme.Builder{GroupVersion: GroupVersion}
 
 	// AddToScheme adds the types in this group-version to the given scheme.

--- a/test/e2e/framework/artifacts/collector.go
+++ b/test/e2e/framework/artifacts/collector.go
@@ -24,7 +24,7 @@ import (
 	"strings"
 	"time"
 
-	. "github.com/onsi/ginkgo/v2" //nolint:golint,revive,staticcheck
+	. "github.com/onsi/ginkgo/v2" //nolint:revive,staticcheck
 
 	"github.com/kaasops/vector-operator/test/e2e/framework/kubectl"
 )

--- a/test/e2e/framework/framework.go
+++ b/test/e2e/framework/framework.go
@@ -29,9 +29,9 @@ import (
 	"sync"
 	"time"
 
-	. "github.com/onsi/ginkgo/v2" //nolint:golint,revive,staticcheck
+	. "github.com/onsi/ginkgo/v2" //nolint:revive,staticcheck
 	"github.com/onsi/ginkgo/v2/types"
-	. "github.com/onsi/gomega" //nolint:golint,revive,staticcheck
+	. "github.com/onsi/gomega" //nolint:revive,staticcheck
 	"k8s.io/apimachinery/pkg/util/wait"
 
 	"github.com/kaasops/vector-operator/test/e2e/framework/config"

--- a/test/e2e/framework/kubectl/wait.go
+++ b/test/e2e/framework/kubectl/wait.go
@@ -22,7 +22,7 @@ import (
 	"strings"
 	"time"
 
-	. "github.com/onsi/gomega" //nolint:golint,revive,staticcheck
+	. "github.com/onsi/gomega" //nolint:revive,staticcheck
 
 	"github.com/kaasops/vector-operator/test/e2e/framework/config"
 	"github.com/kaasops/vector-operator/test/utils"

--- a/test/e2e/framework/lifecycle.go
+++ b/test/e2e/framework/lifecycle.go
@@ -19,7 +19,7 @@ package framework
 import (
 	"time"
 
-	. "github.com/onsi/ginkgo/v2" //nolint:golint,revive,staticcheck
+	. "github.com/onsi/ginkgo/v2" //nolint:revive,staticcheck
 
 	"github.com/kaasops/vector-operator/test/utils"
 )

--- a/test/utils/utils.go
+++ b/test/utils/utils.go
@@ -22,7 +22,7 @@ import (
 	"os/exec"
 	"strings"
 
-	. "github.com/onsi/ginkgo/v2" //nolint:golint,revive,staticcheck
+	. "github.com/onsi/ginkgo/v2" //nolint:revive,staticcheck
 )
 
 const (


### PR DESCRIPTION
## What

Follow-up to the golangci-lint v2 migration. Now that the ST/QF findings are fixed in the tree, remove the temporary `staticcheck.checks: [SA, S]` scope pin so `stylecheck` (ST) and `quickfix` (QF) run by default again — the tree lints clean under the full default check set.

- `api/v1alpha1/groupversion_info.go`: annotate the kubebuilder-scaffolded `scheme.Builder` with `//nolint:staticcheck` (SA1019). It is the upstream kubebuilder v4 scaffold and the generated per-type `init()`s register against its `Register(objects…)` method; migrating to `runtime.NewSchemeBuilder` would change the registration pattern across all API types and diverge from the scaffold.
- Drop the dead `golint` name from the `//nolint` directives (golint was removed in golangci-lint v2; `revive` is its replacement) to silence the `unknown linters` warning.

## Proof

```
$ make lint
golangci-lint run
0 issues.          # no warnings either
```
Unit + envtest suites pass (`make test`). No behavioural change — config + comment-only edits.