### PR TITLE
ci: add Dependabot for gomod, github-actions and docker

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,28 @@
+version: 2
+updates:
+  # Go modules
+  - package-ecosystem: gomod
+    directory: "/"
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 10
+    groups:
+      k8s:
+        patterns:
+          - "k8s.io/*"
+          - "sigs.k8s.io/*"
+      otel:
+        patterns:
+          - "go.opentelemetry.io/*"
+
+  # GitHub Actions used by the workflows
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: weekly
+
+  # Base images in the Dockerfiles
+  - package-ecosystem: docker
+    directory: "/"
+    schedule:
+      interval: weekly


### PR DESCRIPTION
## What

Add `.github/dependabot.yml` to enable weekly automated dependency updates. This keeps the toolchain and dependencies current instead of letting them drift (which is what necessitated the recent manual bump in #235).

Three ecosystems:
- **gomod** (`/`) — Go module updates, with `k8s.io/*`, `sigs.k8s.io/*` and `go.opentelemetry.io/*` **grouped** so related bumps land in a single PR rather than a flood of individual ones.
- **github-actions** (`/`) — keeps the workflow action pins current.
- **docker** (`/`) — tracks the base images in the Dockerfiles.

All on a `weekly` schedule; `open-pull-requests-limit: 10` for gomod.

Config-only change; no code impact.