### PR TITLE
ci: add govulncheck workflow

### DIFF
--- a/.github/workflows/govulncheck.yaml
+++ b/.github/workflows/govulncheck.yaml
@@ -1,0 +1,40 @@
+name: Vulnerability Check
+
+on:
+  push:
+    branches:
+      - main
+      - master
+  pull_request:
+    branches:
+      - main
+      - master
+  schedule:
+    # weekly, so newly disclosed vulnerabilities are caught even without a push
+    - cron: "0 6 * * 1"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  govulncheck:
+    name: govulncheck
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: 'go.mod'
+          cache: true
+
+      - name: Install govulncheck
+        run: go install golang.org/x/vuln/cmd/govulncheck@latest
+
+      - name: Run govulncheck
+        run: govulncheck ./...


### PR DESCRIPTION
## What

Add a `Vulnerability Check` workflow that runs [`govulncheck`](https://pkg.go.dev/golang.org/x/vuln/cmd/govulncheck) against the module set.

Triggers:
- `push` / `pull_request` to `main`/`master` — catch vulnerabilities introduced by dependency or code changes.
- `schedule` (weekly) — catch **newly disclosed** vulnerabilities in unchanged dependencies.
- `workflow_dispatch` — manual runs.

`govulncheck` reports only vulnerabilities that are actually reachable from the code, so it stays low-noise. The tree currently reports **no vulnerabilities**.

New workflow file only; no code impact.