### PR TITLE
build: cross-compile images from $BUILDPLATFORM

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM golang:1.26 AS builder
+FROM --platform=$BUILDPLATFORM golang:1.26 AS builder
 ARG TARGETOS
 ARG TARGETARCH
 ARG VERSION="dev"

--- a/checkpoint_merger.Dockerfile
+++ b/checkpoint_merger.Dockerfile
@@ -1,5 +1,5 @@
 # Build the checkpoint-merger binary
-FROM golang:1.26 AS builder
+FROM --platform=$BUILDPLATFORM golang:1.26 AS builder
 ARG TARGETOS
 ARG TARGETARCH
 ARG VERSION="dev"

--- a/event_collector.Dockerfile
+++ b/event_collector.Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM golang:1.26 AS builder
+FROM --platform=$BUILDPLATFORM golang:1.26 AS builder
 ARG TARGETOS
 ARG TARGETARCH
 ARG VERSION="dev"


### PR DESCRIPTION
## What

Pin the builder stage of all three Dockerfiles to the native build platform:

```diff
-FROM golang:1.26 AS builder
+FROM --platform=$BUILDPLATFORM golang:1.26 AS builder
```

The build already sets `GOARCH=${TARGETARCH}` (and `GOOS=${TARGETOS:-linux}`), so with the builder running on `$BUILDPLATFORM` the Go toolchain **cross-compiles natively** for each target arch instead of running under QEMU emulation for the non-native one. Same resulting images, much faster multi-arch builds.

## Proof

`docker buildx build --platform linux/amd64,linux/arm64` (builder stage rebuilt from scratch, `--no-cache-filter builder`) — all three build cleanly for both architectures:

```
manager:           OK (amd64+arm64) in 87s
event-collector:   OK (amd64+arm64) in 40s
checkpoint-merger: OK (amd64+arm64) in 17s
```

No functional change to the images.