### PR TITLE
build: bump go to 1.26.5 to fix crypto/tls GO-2026-5856

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/kaasops/vector-operator
 
-go 1.26.4
+go 1.26.5
 
 require (
 	github.com/VictoriaMetrics/operator/api v0.72.0


### PR DESCRIPTION
## What

Bump the `go` directive in `go.mod` from `1.26.4` to `1.26.5`.

## Why

`govulncheck` fails CI on a Go standard library vulnerability:

- **GO-2026-5856** — Encrypted Client Hello privacy leak in `crypto/tls`. Found in `crypto/tls@go1.26.4`, fixed in `crypto/tls@go1.26.5`.

It is reached through normal paths (`http.ListenAndServe`, client-go log streaming, e2e helpers), so `govulncheck ./...` reports the code as affected and exits non-zero. All CI workflows build with `go-version-file: go.mod`, so bumping the directive to `1.26.5` picks up the fixed standard library everywhere.

## Verification

`govulncheck ./...` before (go 1.26.4):

```
Vulnerability #1: GO-2026-5856
    Invoking Encrypted Client Hello privacy leak in crypto/tls
  Standard library
    Found in: crypto/tls@go1.26.4
    Fixed in: crypto/tls@go1.26.5
Your code is affected by 1 vulnerability from the Go standard library.
```

After (go 1.26.5):

```
No vulnerabilities found.
Your code is affected by 0 vulnerabilities.
```

`go build ./...` and `go vet ./...` pass on 1.26.5.