### PR TITLE
ci: publish e2e results to the job summary instead of a check run

### DIFF
--- a/.github/workflows/e2e-tests.yaml
+++ b/.github/workflows/e2e-tests.yaml
@@ -11,6 +11,9 @@ on:
       - master
   workflow_dispatch:  # Allow manual trigger
 
+permissions:
+  contents: read
+
 jobs:
   e2e-tests:
     name: Run E2E Tests (${{ matrix.k8s }})
@@ -65,10 +68,12 @@ jobs:
           path: test/e2e/results/
           retention-days: 7
 
+      # Runs from Dependabot PRs and forks get a read-only GITHUB_TOKEN, so creating a
+      # check run fails with 403. Report into the job summary instead, which needs no token.
       - name: Publish test results
         if: always()
         uses: EnricoMi/publish-unit-test-result-action@v2
         with:
           files: test/e2e/results/run-*/reports/junit-report.xml
-          check_name: E2E Test Results (${{ matrix.k8s }})
           comment_mode: off
+          check_run: false


### PR DESCRIPTION
E2E is red on every Dependabot PR while the tests themselves pass: the last step fails with `Resource not accessible by integration: 403` on `create-a-check-run`. Creating a check run needs `checks: write`, but runs triggered by Dependabot PRs [use a read-only `GITHUB_TOKEN`](https://docs.github.com/en/code-security/dependabot/working-with-dependabot/automating-dependabot-with-github-actions). PRs from forks fail the same way.

Publishing to the job summary (`check_run: false`) needs no token, so it works the same for `main`, Dependabot and forks. Verified on a branch with the token restricted to `contents: read`: the current config fails with the 403, this one logs `Created job summary` and passes. `check_name` only named the check run, so it goes; `main` has no required checks, so nothing is blocked. Results stay in the job summary and the `e2e-results-*` artifact.

Once this lands, the open Dependabot PRs need a rebase to pick up the fixed workflow.