### PR TITLE
ci: set open-pull-requests-limit for github-actions and docker updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -20,9 +20,11 @@ updates:
     directory: "/"
     schedule:
       interval: weekly
+    open-pull-requests-limit: 10
 
   # Base images in the Dockerfiles
   - package-ecosystem: docker
     directory: "/"
     schedule:
       interval: weekly
+    open-pull-requests-limit: 10


### PR DESCRIPTION
The `github-actions` and `docker` update sections had no `open-pull-requests-limit`, so both fell back to the default of 5 open PRs. The `gomod` section already sets it to 10.

That default silently dropped available major bumps. In Dependabot's only actions run (2026-07-03) it opened 6 action bumps but skipped `actions/setup-go` v5→v6 (available since 2025-09-04) and `docker/build-push-action` v6→v7 (available since 2026-03-05); both are handled in separate PRs. Raising the limit to 10 keeps Dependabot from dropping bumps once more than a handful are outstanding, matching the `gomod` section.