### PR TITLE
ci: bump docker/build-push-action from v6 to v7

### DIFF
--- a/.github/workflows/build-image.yaml
+++ b/.github/workflows/build-image.yaml
@@ -31,7 +31,7 @@ jobs:
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Build operator image and push to Docker Hub
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: .
           platforms: linux/amd64,linux/arm64
@@ -40,7 +40,7 @@ jobs:
           tags: ${{ secrets.DOCKERHUB_USERNAME }}/${{ github.event.repository.name }}:${{ steps.tag.outputs.TAG }},${{ secrets.DOCKERHUB_USERNAME }}/${{ github.event.repository.name }}:latest
 
       - name: Build event-collector image and push to Docker Hub
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: .
           file: event_collector.Dockerfile
@@ -50,7 +50,7 @@ jobs:
           tags: ${{ secrets.DOCKERHUB_USERNAME }}/event-collector:${{ steps.tag.outputs.TAG }},${{ secrets.DOCKERHUB_USERNAME }}/event-collector:latest
 
       - name: Build checkpoint-merger image and push to Docker Hub
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: .
           file: checkpoint_merger.Dockerfile


### PR DESCRIPTION
`docker/build-push-action@v6` is a major version behind (v7 available since 2026-03-05). Dependabot skipped this bump because the `github-actions` section had no `open-pull-requests-limit` and hit the default of 5 open PRs.

v7 moves the runtime to Node 24 / ESM and removes the deprecated `DOCKER_BUILD_NO_SUMMARY` and `DOCKER_BUILD_EXPORT_RETENTION_DAYS` env vars; neither is set anywhere in this repo, and all three steps only use `context` / `file` / `platforms` / `push` / `build-args` / `tags`.

Note: this action runs only in `build-image.yaml`, which triggers on tag pushes, so PR CI does not exercise it — it will first run on the next release tag.