### PR TITLE
fix: keep aggregator volume order stable to avoid rollout on operator upgrade

### DIFF
--- a/internal/vector/aggregator/deployment.go
+++ b/internal/vector/aggregator/deployment.go
@@ -197,26 +197,12 @@ func (ctrl *Controller) generateVectorAggregatorVolume() []corev1.Volume {
 			Name:         "config",
 			VolumeSource: configVolumeSource,
 		},
-		{
-			Name: "procfs",
-			VolumeSource: corev1.VolumeSource{
-				HostPath: &corev1.HostPathVolumeSource{
-					Path: "/proc",
-				},
-			},
-		},
-		{
-			Name: "sysfs",
-			VolumeSource: corev1.VolumeSource{
-				HostPath: &corev1.HostPathVolumeSource{
-					Path: "/sys",
-				},
-			},
-		},
 	}
 
 	// In persistent mode the data volume comes from the StatefulSet volume claim
 	// template, so only add the hostPath data volume for the Deployment path.
+	// Keep it right after "config": reordering the volume list changes the pod
+	// template and rolls every non-persistent aggregator on operator upgrade.
 	if !ctrl.persistenceEnabled() {
 		requiredVolumes = append(requiredVolumes, corev1.Volume{
 			Name: dataVolumeName,
@@ -227,6 +213,25 @@ func (ctrl *Controller) generateVectorAggregatorVolume() []corev1.Volume {
 			},
 		})
 	}
+
+	requiredVolumes = append(requiredVolumes,
+		corev1.Volume{
+			Name: "procfs",
+			VolumeSource: corev1.VolumeSource{
+				HostPath: &corev1.HostPathVolumeSource{
+					Path: "/proc",
+				},
+			},
+		},
+		corev1.Volume{
+			Name: "sysfs",
+			VolumeSource: corev1.VolumeSource{
+				HostPath: &corev1.HostPathVolumeSource{
+					Path: "/sys",
+				},
+			},
+		},
+	)
 
 	// Only add volumes that don't already exist
 	for _, reqVol := range requiredVolumes {

--- a/internal/vector/aggregator/deployment_test.go
+++ b/internal/vector/aggregator/deployment_test.go
@@ -1,0 +1,25 @@
+package aggregator
+
+import (
+	"testing"
+
+	. "github.com/onsi/gomega"
+
+	vectorv1alpha1 "github.com/kaasops/vector-operator/api/v1alpha1"
+)
+
+func TestGenerateVolumesKeepsPreUpgradeOrderWhenNotPersistent(t *testing.T) {
+	g := NewWithT(t)
+
+	ctrl := createTestController("test", "default", &vectorv1alpha1.VectorAggregatorCommon{}, false)
+
+	volumes := ctrl.generateVectorAggregatorVolume()
+
+	names := make([]string, 0, len(volumes))
+	for _, v := range volumes {
+		names = append(names, v.Name)
+	}
+	// The exact order v0.4.1 generated: a reordered (even if semantically equal)
+	// pod template rolls every aggregator Deployment on operator upgrade.
+	g.Expect(names).To(Equal([]string{"config", "data", "procfs", "sysfs"}))
+}


### PR DESCRIPTION
#251 moved the aggregator's `data` volume from the static required-volumes list to a conditional append after `procfs`/`sysfs`, so for non-persistent aggregators the generated pod template volume order changed from `[config, data, procfs, sysfs]` to `[config, procfs, sysfs, data]`. The volume set is identical, but the order change makes a different pod template, so every VectorAggregator and ClusterVectorAggregator with persistence disabled is rolled once when the operator is upgraded.

This PR inserts the `data` volume back at its original position (right after `config`) and adds a regression test pinning the order. Persistent mode is unchanged (the data volume still comes from the StatefulSet volume claim template); volumeMounts order was never affected.

Verified with an upgrade test on kind (v1.31.9 and v1.36.1): v0.4.1 operator → this branch over the same CRs — with this fix the aggregator Deployment generation, ReplicaSet and pods stay untouched, config secrets byte-identical; without it the Deployment rolls immediately on operator start.