### PR TITLE
fix: reconcile starvation around configcheck pods and pipeline event debouncing

### DIFF
--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -363,7 +363,10 @@ func reconcileWithDelay(ctx context.Context, in, out chan event.GenericEvent, de
 		case <-ctx.Done():
 			return
 		case ev := <-in:
-			ticker.Reset(delay)
+			// Coalesce events per object into the current window. Do NOT reset the
+			// ticker here: under a continuous stream (events arriving faster than
+			// delay) resetting would postpone the flush indefinitely and starve
+			// agent reconciles, leaving their config secret stale/unbuilt.
 			key := fmt.Sprintf("%s/%s", ev.Object.GetNamespace(), ev.Object.GetName())
 			if _, ok := store[key]; !ok {
 				store[key] = ev

--- a/cmd/manager/main_test.go
+++ b/cmd/manager/main_test.go
@@ -1,0 +1,68 @@
+/*
+Copyright 2024.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+)
+
+// Under a continuous stream of pipeline events arriving faster than the debounce
+// delay, reconcileWithDelay must still flush queued agent reconciles. If it resets
+// its timer on every event it starves — agents never get reconciled and their config
+// secret is never (re)built, which is the e2e flake this reproduces deterministically.
+func TestReconcileWithDelayFlushesUnderContinuousLoad(t *testing.T) {
+	in := make(chan event.GenericEvent, 100)
+	out := make(chan event.GenericEvent, 100)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	delay := 50 * time.Millisecond
+	go reconcileWithDelay(ctx, in, out, delay)
+
+	obj := &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Namespace: "ns", Name: "agent"}}
+	stop := make(chan struct{})
+	defer close(stop)
+	go func() {
+		tk := time.NewTicker(delay / 5) // events arrive faster than the debounce window
+		defer tk.Stop()
+		for {
+			select {
+			case <-stop:
+				return
+			case <-tk.C:
+				select {
+				case in <- event.GenericEvent{Object: obj}:
+				case <-stop:
+					return
+				}
+			}
+		}
+	}()
+
+	select {
+	case <-out:
+		// flushed despite continuous load — correct
+	case <-time.After(delay * 10):
+		t.Fatal("reconcileWithDelay never flushed under continuous load (debounce starvation)")
+	}
+}

--- a/internal/config/configcheck/configcheck.go
+++ b/internal/config/configcheck/configcheck.go
@@ -122,9 +122,35 @@ func New(
 	}
 }
 
+// namespaceIsTerminating reports whether the target namespace is being deleted or
+// already gone. A ConfigCheck launched into such a namespace can never create its
+// pod/secret — the API server rejects new content — so the caller must skip it
+// instead of blocking a reconcile worker until ConfigCheckTimeout.
+func (cc *ConfigCheck) namespaceIsTerminating(ctx context.Context) (bool, error) {
+	ns := &corev1.Namespace{}
+	if err := cc.Client.Get(ctx, types.NamespacedName{Name: cc.Namespace}, ns); err != nil {
+		if api_errors.IsNotFound(err) {
+			// namespace already gone — nothing to validate into, treat as terminating (skip)
+			return true, nil
+		}
+		return false, err
+	}
+	return ns.DeletionTimestamp != nil, nil
+}
+
 func (cc *ConfigCheck) Run(ctx context.Context) (string, error) {
 	log := log.FromContext(ctx).WithValues("Vector ConfigCheck", cc.Initiator)
 	log.Info("================= Started ConfigCheck =================")
+
+	// A terminating namespace cannot accept new content, so the configcheck pod and
+	// secret would never be admitted and getCheckResult would block until
+	// ConfigCheckTimeout, holding the reconcile worker. Skip instead.
+	if terminating, err := cc.namespaceIsTerminating(ctx); err != nil {
+		return "", err
+	} else if terminating {
+		log.Info("Skipping ConfigCheck: namespace is terminating or gone", "namespace", cc.Namespace)
+		return "", ErrConfigcheckSkipped
+	}
 
 	if err := cc.ensureVectorConfigCheckRBAC(ctx); err != nil && !api_errors.IsAlreadyExists(err) { // TODO(aa1ex): error is silenced, is that ok?
 		return "", err

--- a/internal/config/configcheck/configcheck.go
+++ b/internal/config/configcheck/configcheck.go
@@ -127,15 +127,7 @@ func New(
 // pod/secret — the API server rejects new content — so the caller must skip it
 // instead of blocking a reconcile worker until ConfigCheckTimeout.
 func (cc *ConfigCheck) namespaceIsTerminating(ctx context.Context) (bool, error) {
-	ns := &corev1.Namespace{}
-	if err := cc.Client.Get(ctx, types.NamespacedName{Name: cc.Namespace}, ns); err != nil {
-		if api_errors.IsNotFound(err) {
-			// namespace already gone — nothing to validate into, treat as terminating (skip)
-			return true, nil
-		}
-		return false, err
-	}
-	return ns.DeletionTimestamp != nil, nil
+	return k8s.NamespaceIsTerminating(ctx, cc.Client, cc.Namespace)
 }
 
 func (cc *ConfigCheck) Run(ctx context.Context) (string, error) {

--- a/internal/config/configcheck/configcheck.go
+++ b/internal/config/configcheck/configcheck.go
@@ -19,6 +19,7 @@ package configcheck
 import (
 	"context"
 	"errors"
+	"fmt"
 	"math/rand"
 	"time"
 
@@ -227,6 +228,26 @@ func randStringRunes() string {
 	return string(b)
 }
 
+// unstartableReason reports a container waiting state that cannot resolve without a
+// spec change (missing secret/configmap referenced by env, invalid image name), so
+// waiting for the configcheck pod to complete is pointless.
+func unstartableReason(pod *corev1.Pod) (string, bool) {
+	statuses := make([]corev1.ContainerStatus, 0, len(pod.Status.InitContainerStatuses)+len(pod.Status.ContainerStatuses))
+	statuses = append(statuses, pod.Status.InitContainerStatuses...)
+	statuses = append(statuses, pod.Status.ContainerStatuses...)
+	for _, st := range statuses {
+		w := st.State.Waiting
+		if w == nil {
+			continue
+		}
+		switch w.Reason {
+		case "CreateContainerConfigError", "InvalidImageName":
+			return fmt.Sprintf("configcheck pod cannot start, %s: %s", w.Reason, w.Message), true
+		}
+	}
+	return "", false
+}
+
 func (cc *ConfigCheck) getCheckResult(ctx context.Context, pod *corev1.Pod) (reason string, err error) {
 	log := log.FromContext(ctx).WithValues("Vector ConfigCheck", pod.Name)
 	log.Info("Trying to get configcheck result")
@@ -251,16 +272,21 @@ func (cc *ConfigCheck) getCheckResult(ctx context.Context, pod *corev1.Pod) (rea
 
 	for {
 		select {
-		case e := <-watcher.ResultChan():
-			if e.Object == nil {
-				return "", nil
+		case e, open := <-watcher.ResultChan():
+			if !open {
+				// We lost sight of the pod; reporting success here would let an
+				// unvalidated config through.
+				return "", fmt.Errorf("configcheck: watch for pod %s closed before a result", pod.Name)
 			}
 			pod, ok := e.Object.(*corev1.Pod)
 			if !ok {
 				continue
 			}
 			switch e.Type {
-			case watch.Modified:
+			// Added matters too: a resourceVersion-less watch is seeded with synthetic
+			// Added events, so a pod that reached a final state before the watch was
+			// established would otherwise be ignored until ConfigCheckTimeout.
+			case watch.Added, watch.Modified:
 				if pod.DeletionTimestamp != nil {
 					continue
 				}
@@ -275,7 +301,17 @@ func (cc *ConfigCheck) getCheckResult(ctx context.Context, pod *corev1.Pod) (rea
 						return "", err
 					}
 					return reason, ErrValidation
+				default:
+					// A pod that can never start (e.g. env from a missing secret →
+					// CreateContainerConfigError) stays Pending forever; fail the check
+					// now instead of holding the reconcile worker until timeout.
+					if reason, unstartable := unstartableReason(pod); unstartable {
+						log.Info("Config Check pod cannot start", "reason", reason)
+						return reason, ErrValidation
+					}
 				}
+			case watch.Deleted:
+				return "", fmt.Errorf("configcheck: pod %s was deleted before producing a result", pod.Name)
 			}
 			// Reset timer after processing event to restart timeout window
 			if !timer.Stop() {

--- a/internal/config/configcheck/configcheck_error.go
+++ b/internal/config/configcheck/configcheck_error.go
@@ -23,4 +23,8 @@ import (
 var (
 	ErrValidation         = errors.New("config validation error")
 	ErrConfigcheckTimeout = errors.New("timeout waiting configcheck pod result")
+	// ErrConfigcheckSkipped signals that the check did not run because its target
+	// namespace is terminating (or gone). Callers should treat it as a no-op skip,
+	// not a validation failure — the config was never checked.
+	ErrConfigcheckSkipped = errors.New("configcheck skipped: namespace is terminating")
 )

--- a/internal/config/configcheck/namespace_test.go
+++ b/internal/config/configcheck/namespace_test.go
@@ -1,0 +1,99 @@
+/*
+Copyright 2024.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package configcheck
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+func newCCWithNamespace(objs ...client.Object) *ConfigCheck {
+	scheme := runtime.NewScheme()
+	_ = corev1.AddToScheme(scheme)
+	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(objs...).Build()
+	return &ConfigCheck{Client: c, Namespace: "target"}
+}
+
+// A ConfigCheck launched into a terminating (or already gone) namespace can never
+// create its pod/secret — the API server rejects new content — so it must be skipped
+// instead of blocking a reconcile worker until ConfigCheckTimeout.
+func TestNamespaceIsTerminating(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("active namespace is not terminating", func(t *testing.T) {
+		ns := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "target"}}
+		terminating, err := newCCWithNamespace(ns).namespaceIsTerminating(ctx)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if terminating {
+			t.Fatalf("active namespace reported as terminating")
+		}
+	})
+
+	t.Run("namespace with deletion timestamp is terminating", func(t *testing.T) {
+		now := metav1.Now()
+		ns := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{
+			Name:              "target",
+			DeletionTimestamp: &now,
+			Finalizers:        []string{"kubernetes"},
+		}}
+		terminating, err := newCCWithNamespace(ns).namespaceIsTerminating(ctx)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if !terminating {
+			t.Fatalf("terminating namespace reported as active")
+		}
+	})
+
+	t.Run("missing namespace is treated as terminating", func(t *testing.T) {
+		terminating, err := newCCWithNamespace().namespaceIsTerminating(ctx)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if !terminating {
+			t.Fatalf("missing namespace should be treated as terminating (skip)")
+		}
+	})
+}
+
+// Run must bail out early with ErrConfigcheckSkipped when the target namespace is
+// terminating, before creating any pod/secret — otherwise it blocks a reconcile
+// worker until ConfigCheckTimeout waiting for a pod the API server won't admit.
+func TestRunSkipsTerminatingNamespace(t *testing.T) {
+	now := metav1.Now()
+	ns := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{
+		Name:              "target",
+		DeletionTimestamp: &now,
+		Finalizers:        []string{"kubernetes"},
+	}}
+	cc := newCCWithNamespace(ns)
+	cc.Name = "agent"
+
+	_, err := cc.Run(context.Background())
+	if !errors.Is(err, ErrConfigcheckSkipped) {
+		t.Fatalf("want ErrConfigcheckSkipped, got %v", err)
+	}
+}

--- a/internal/config/configcheck/watch_test.go
+++ b/internal/config/configcheck/watch_test.go
@@ -1,0 +1,135 @@
+/*
+Copyright 2024.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package configcheck
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/watch"
+	k8sfake "k8s.io/client-go/kubernetes/fake"
+	k8stesting "k8s.io/client-go/testing"
+)
+
+type checkResult struct {
+	reason string
+	err    error
+}
+
+// startGetCheckResult runs getCheckResult against a fake watcher the test controls.
+// The timeout is short so a starved wait surfaces as ErrConfigcheckTimeout quickly.
+func startGetCheckResult(t *testing.T, timeout time.Duration) (*watch.FakeWatcher, *corev1.Pod, chan checkResult) {
+	t.Helper()
+	cs := k8sfake.NewSimpleClientset()
+	fw := watch.NewFakeWithChanSize(4, false)
+	cs.PrependWatchReactor("pods", k8stesting.DefaultWatchReactor(fw, nil))
+
+	cc := &ConfigCheck{ClientSet: cs, Namespace: "ns", ConfigCheckTimeout: timeout}
+	pod := &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Namespace: "ns", Name: "configcheck-x"}}
+
+	res := make(chan checkResult, 1)
+	go func() {
+		reason, err := cc.getCheckResult(context.Background(), pod)
+		res <- checkResult{reason, err}
+	}()
+	return fw, pod, res
+}
+
+func waitResult(t *testing.T, res chan checkResult, within time.Duration) checkResult {
+	t.Helper()
+	select {
+	case r := <-res:
+		return r
+	case <-time.After(within):
+		t.Fatal("getCheckResult did not return in time")
+		return checkResult{}
+	}
+}
+
+// A configcheck pod that can never start (e.g. env references a missing secret →
+// CreateContainerConfigError) must fail the check immediately instead of holding
+// the reconcile worker until ConfigCheckTimeout.
+func TestGetCheckResultFailsFastOnUnstartablePod(t *testing.T) {
+	fw, pod, res := startGetCheckResult(t, 5*time.Second)
+
+	bad := pod.DeepCopy()
+	bad.Status.Phase = corev1.PodPending
+	bad.Status.ContainerStatuses = []corev1.ContainerStatus{{
+		State: corev1.ContainerState{Waiting: &corev1.ContainerStateWaiting{
+			Reason:  "CreateContainerConfigError",
+			Message: `secret "no-such-secret" not found`,
+		}},
+	}}
+	fw.Modify(bad)
+
+	r := waitResult(t, res, 2*time.Second) // well under the 5s timeout
+	if !errors.Is(r.err, ErrValidation) {
+		t.Fatalf("want ErrValidation, got err=%v reason=%q", r.err, r.reason)
+	}
+	if !strings.Contains(r.reason, "CreateContainerConfigError") {
+		t.Fatalf("reason should carry the waiting reason, got %q", r.reason)
+	}
+}
+
+// The API server seeds a resourceVersion-less watch with synthetic Added events; a pod
+// that completed before the watch was established arrives as Added, not Modified, and
+// must be treated as a result rather than ignored until timeout.
+func TestGetCheckResultHandlesInitialAddedEvent(t *testing.T) {
+	fw, pod, res := startGetCheckResult(t, 5*time.Second)
+
+	done := pod.DeepCopy()
+	done.Status.Phase = corev1.PodSucceeded
+	fw.Add(done)
+
+	r := waitResult(t, res, 2*time.Second)
+	if r.err != nil || r.reason != "" {
+		t.Fatalf("want success, got err=%v reason=%q", r.err, r.reason)
+	}
+}
+
+// If the configcheck pod is deleted before completing (namespace teardown, manual
+// cleanup), the check can never produce a result — bail out instead of waiting.
+func TestGetCheckResultFailsWhenPodDeleted(t *testing.T) {
+	fw, pod, res := startGetCheckResult(t, 5*time.Second)
+
+	fw.Delete(pod.DeepCopy())
+
+	r := waitResult(t, res, 2*time.Second)
+	if r.err == nil {
+		t.Fatalf("want error on deleted pod, got success (reason=%q)", r.reason)
+	}
+}
+
+// A closed watch channel means we lost sight of the pod; reporting success would let
+// an unvalidated config through. It must surface as an error.
+func TestGetCheckResultErrsOnClosedWatchChannel(t *testing.T) {
+	fw, _, res := startGetCheckResult(t, 5*time.Second)
+
+	// give the watch loop a moment to start consuming, then close the stream
+	time.Sleep(50 * time.Millisecond)
+	fw.Stop()
+
+	r := waitResult(t, res, 2*time.Second)
+	if r.err == nil {
+		t.Fatalf("want error on closed watch, got success (reason=%q)", r.reason)
+	}
+}

--- a/internal/controller/clustervectoraggregator_controller.go
+++ b/internal/controller/clustervectoraggregator_controller.go
@@ -163,6 +163,11 @@ func (r *ClusterVectorAggregatorReconciler) createOrUpdateVectorAggregator(ctx c
 					log.Error(err, "Invalid config")
 					return ctrl.Result{}, nil
 				}
+				if errors.Is(err, configcheck.ErrConfigcheckSkipped) {
+					// namespace is terminating; the aggregator is on its way out, nothing to do
+					log.Info("ConfigCheck skipped, namespace is terminating")
+					return ctrl.Result{}, nil
+				}
 				return ctrl.Result{}, err
 			}
 		}

--- a/internal/controller/clustervectoraggregator_controller.go
+++ b/internal/controller/clustervectoraggregator_controller.go
@@ -113,6 +113,16 @@ func (r *ClusterVectorAggregatorReconciler) createOrUpdateVectorAggregator(ctx c
 		return ctrl.Result{}, nil
 	}
 
+	// resourceNamespace may be terminating or already deleted (e.g. left behind after the
+	// namespace it targeted was removed). Reconciling into it only produces errors and
+	// requeues that starve the (serial) worker, so skip until it is gone.
+	if terminating, err := k8s.NamespaceIsTerminating(ctx, client, vaCtrl.Namespace); err != nil {
+		return ctrl.Result{}, err
+	} else if terminating {
+		log.Info("Skip reconcile: resourceNamespace is terminating or gone", "namespace", vaCtrl.Namespace)
+		return ctrl.Result{}, nil
+	}
+
 	pipelines, err := pipeline.GetValidPipelines(ctx, vaCtrl.Client, pipeline.FilterPipelines{
 		Scope:    pipeline.ClusterPipelines,
 		Selector: v.Spec.Selector,

--- a/internal/controller/pipeline_controller.go
+++ b/internal/controller/pipeline_controller.go
@@ -184,6 +184,9 @@ func (r *PipelineReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 				)
 
 				reason, err := configCheck.Run(ctx)
+				if errors.Is(err, configcheck.ErrConfigcheckSkipped) {
+					return nil
+				}
 				if reason != "" {
 					return fmt.Errorf("agent %s/%s config check failed: %s", vector.Namespace, vector.Name, reason)
 				}
@@ -242,6 +245,9 @@ func (r *PipelineReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 					)
 
 					reason, err := configCheck.Run(ctx)
+					if errors.Is(err, configcheck.ErrConfigcheckSkipped) {
+						return nil
+					}
 					if reason != "" {
 						return fmt.Errorf("aggregator %s/%s config check failed: %s", vector.Namespace, vector.Name, reason)
 					}
@@ -295,6 +301,9 @@ func (r *PipelineReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 					)
 
 					reason, err := configCheck.Run(ctx)
+					if errors.Is(err, configcheck.ErrConfigcheckSkipped) {
+						return nil
+					}
 					if reason != "" {
 						return fmt.Errorf("cluster aggregator %s/%s config check failed: %s", vector.Namespace, vector.Name, reason)
 					}

--- a/internal/controller/vector_controller.go
+++ b/internal/controller/vector_controller.go
@@ -245,6 +245,11 @@ func (r *VectorReconciler) createOrUpdateVector(ctx context.Context, client clie
 					log.Error(err, "Invalid config")
 					return ctrl.Result{}, nil
 				}
+				if errors.Is(err, configcheck.ErrConfigcheckSkipped) {
+					// namespace is terminating; the Vector CR is on its way out, nothing to do
+					log.Info("ConfigCheck skipped, namespace is terminating")
+					return ctrl.Result{}, nil
+				}
 				return ctrl.Result{}, err
 			}
 		}

--- a/internal/controller/vector_controller.go
+++ b/internal/controller/vector_controller.go
@@ -188,6 +188,16 @@ func (r *VectorReconciler) reconcileVectors(ctx context.Context, client client.C
 
 func (r *VectorReconciler) createOrUpdateVector(ctx context.Context, client client.Client, clientset *kubernetes.Clientset, v *v1alpha1.Vector) (ctrl.Result, error) {
 	log := log.FromContext(ctx).WithValues("Vector", v.Name)
+
+	// A terminating namespace rejects new content, so reconciling into it only produces
+	// errors and requeues that starve the (serial) worker until the namespace is gone.
+	if terminating, err := k8s.NamespaceIsTerminating(ctx, client, v.Namespace); err != nil {
+		return ctrl.Result{}, err
+	} else if terminating {
+		log.Info("Skip reconcile: namespace is terminating or gone", "namespace", v.Namespace)
+		return ctrl.Result{}, nil
+	}
+
 	// Init Controller for Vector Agent
 	vaCtrl := vectoragent.NewController(v, client, clientset)
 

--- a/internal/controller/vectoraggregator_controller.go
+++ b/internal/controller/vectoraggregator_controller.go
@@ -240,6 +240,11 @@ func (r *VectorAggregatorReconciler) createOrUpdateVectorAggregator(ctx context.
 					log.Error(err, "Invalid config")
 					return ctrl.Result{}, nil
 				}
+				if errors.Is(err, configcheck.ErrConfigcheckSkipped) {
+					// namespace is terminating; the aggregator is on its way out, nothing to do
+					log.Info("ConfigCheck skipped, namespace is terminating")
+					return ctrl.Result{}, nil
+				}
 				return ctrl.Result{}, err
 			}
 		}

--- a/internal/controller/vectoraggregator_controller.go
+++ b/internal/controller/vectoraggregator_controller.go
@@ -187,6 +187,16 @@ func listVectorAggregators(ctx context.Context, client client.Client) (vectors [
 
 func (r *VectorAggregatorReconciler) createOrUpdateVectorAggregator(ctx context.Context, client client.Client, clientset *kubernetes.Clientset, v *v1alpha1.VectorAggregator) (ctrl.Result, error) {
 	log := log.FromContext(ctx).WithValues("VectorAggregator", v.Name)
+
+	// A terminating namespace rejects new content, so reconciling into it only produces
+	// errors and requeues that starve the (serial) worker until the namespace is gone.
+	if terminating, err := k8s.NamespaceIsTerminating(ctx, client, v.Namespace); err != nil {
+		return ctrl.Result{}, err
+	} else if terminating {
+		log.Info("Skip reconcile: namespace is terminating or gone", "namespace", v.Namespace)
+		return ctrl.Result{}, nil
+	}
+
 	vaCtrl := aggregator.NewController(v, client, clientset)
 
 	pipelines, err := pipeline.GetValidPipelines(ctx, vaCtrl.Client, pipeline.FilterPipelines{

--- a/internal/utils/k8s/namespace.go
+++ b/internal/utils/k8s/namespace.go
@@ -1,0 +1,41 @@
+/*
+Copyright 2024.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package k8s
+
+import (
+	"context"
+
+	corev1 "k8s.io/api/core/v1"
+	api_errors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// NamespaceIsTerminating reports whether the named namespace is being deleted or
+// already gone. Reconciling resources (secrets, daemonsets, configcheck pods) into
+// such a namespace is futile — the API server rejects new content — so callers
+// should skip instead of erroring and requeuing forever.
+func NamespaceIsTerminating(ctx context.Context, c client.Client, name string) (bool, error) {
+	ns := &corev1.Namespace{}
+	if err := c.Get(ctx, types.NamespacedName{Name: name}, ns); err != nil {
+		if api_errors.IsNotFound(err) {
+			return true, nil
+		}
+		return false, err
+	}
+	return ns.DeletionTimestamp != nil, nil
+}

--- a/internal/utils/k8s/namespace_test.go
+++ b/internal/utils/k8s/namespace_test.go
@@ -1,0 +1,72 @@
+/*
+Copyright 2024.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package k8s
+
+import (
+	"context"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+func TestNamespaceIsTerminating(t *testing.T) {
+	ctx := context.Background()
+	build := func(objs ...client.Object) client.Client {
+		return fake.NewClientBuilder().WithObjects(objs...).Build()
+	}
+
+	t.Run("active namespace", func(t *testing.T) {
+		c := build(&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "ns"}})
+		got, err := NamespaceIsTerminating(ctx, c, "ns")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if got {
+			t.Fatalf("active namespace reported terminating")
+		}
+	})
+
+	t.Run("terminating namespace", func(t *testing.T) {
+		now := metav1.Now()
+		c := build(&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{
+			Name:              "ns",
+			DeletionTimestamp: &now,
+			Finalizers:        []string{"kubernetes"},
+		}})
+		got, err := NamespaceIsTerminating(ctx, c, "ns")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if !got {
+			t.Fatalf("terminating namespace reported active")
+		}
+	})
+
+	t.Run("missing namespace treated as terminating", func(t *testing.T) {
+		c := build()
+		got, err := NamespaceIsTerminating(ctx, c, "ns")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if !got {
+			t.Fatalf("missing namespace should be treated as terminating")
+		}
+	})
+}

--- a/test/e2e/podmonitor_e2e_test.go
+++ b/test/e2e/podmonitor_e2e_test.go
@@ -41,6 +41,10 @@ var _ = Describe("PodMonitor Configuration", Label(config.LabelSmoke, config.Lab
 	})
 
 	AfterAll(func() {
+		// Cluster-scoped aggregators outlive the namespace; delete them so the operator
+		// does not keep reconciling them into the torn-down namespace.
+		f.DeleteClusterResource("clustervectoraggregator", "podmonitor-cluster-agg")
+		f.DeleteClusterResource("clustervectoraggregator", "podmonitor-cluster-agg-defaults")
 		f.Teardown()
 		f.PrintMetrics()
 	})


### PR DESCRIPTION
### Problem

The e2e suite flakes with `Timed out after 120s` waiting for an agent config secret (seen on reruns of #253/#257/#258 and reproducible on a v1.32.11 kind cluster). Tracing it surfaced four independent defects, all starving the serial (`MaxConcurrentReconciles=1`) reconcile workers:

1. A configcheck launched into a terminating namespace can never create its pod/secret (`unable to create new content in namespace ... because it is being terminated`), so `getCheckResult` holds the worker for the full `ConfigCheckTimeout` (300s); one CI run showed 30 failed reconciles plus two back-to-back 300s stalls.
2. Reconciling a CR whose target namespace is gone keeps erroring and requeueing forever — leaked cluster-scoped `ClusterVectorAggregator`s from e2e kept pointing `resourceNamespace` at deleted namespaces, spamming `failed to create or update Secret: namespaces ... not found`.
3. The pipeline→agent debounce (`reconcileWithDelay`) resets its ticker on every incoming event, so events arriving faster than the 10s delay postpone the flush indefinitely and agents stop being notified at all.
4. A configcheck pod that can never start (e.g. CR `env` referencing a missing secret → `CreateContainerConfigError`; the configcheck pod inherits the CR's env) stays Pending forever, and `getCheckResult` only reacted to `Modified` events with `Succeeded`/`Failed` phases — every reconcile burned the full 300s. The same watch loop also ignored the initial synthetic `Added` events and `Deleted` events, and treated a closed watch channel as success, letting an unvalidated config through.

### Fixes (one commit per defect)

- `configcheck.Run` returns a new `ErrConfigcheckSkipped` sentinel when the target namespace is terminating or gone; all call sites treat it as a no-op skip.
- Vector / VectorAggregator / ClusterVectorAggregator reconcilers skip early when the target namespace (for CVA — `spec.resourceNamespace`) is terminating or gone, via a shared `k8s.NamespaceIsTerminating` helper; the podmonitor e2e now deletes its cluster-scoped aggregators in `AfterAll`.
- `reconcileWithDelay` coalesces events and flushes every `delay` instead of resetting the ticker per event, so notifications survive continuous load.
- `getCheckResult` fails fast with the container's waiting reason when the pod is unstartable (`CreateContainerConfigError`, `InvalidImageName`) — the CR gets a Failed status carrying the actual cause within seconds; it also handles `Added`, errors on `Deleted`, and errors on a closed watch channel instead of reporting success.

### Verification

- TDD unit tests per fix (`configcheck/namespace_test.go`, `configcheck/watch_test.go`, `utils/k8s/namespace_test.go`, `cmd/manager/main_test.go`); `make test` green.
- kind v1.32.11 (CI matrix pin): before the fixes the full suite failed on the first run with this flake; with all four fixes it passed 4/4 consecutive full-suite runs with zero configcheck timeouts, and full-suite time dropped from ~23 to ~11.5 minutes (two 300s configcheck stalls per run gone).
- Live check: a `VectorAggregator` whose `env` references a missing secret reaches `configCheckResult: false` with reason `configcheck pod cannot start, CreateContainerConfigError: secret "no-such-secret" not found` in ~25s; before the fix its configcheck pod sat in `CreateContainerConfigError` until the 300s timeout on every reconcile.

Behavior note: an unstartable configcheck pod is now reported as a validation failure (Failed status with reason) instead of a silent timeout-and-requeue loop; fixing the CR or creating the missing secret re-triggers reconciliation as usual.

Follow-up intentionally left out: raising `MaxConcurrentReconciles` for the Vector controllers — serialization amplifies any single stall and deserves its own discussion.