### PR TITLE
docs: add upgrading section covering manual CRD updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ Connect us in Telegram - https://t.me/+Y0PzGa1d5DFiYThi
 
 ## Documentation
 - Quick start [doc](https://github.com/kaasops/vector-operator/blob/main/docs/quick-start.md)
+- Upgrading [doc](https://github.com/kaasops/vector-operator/blob/main/docs/quick-start.md#upgrading)
 - Design [doc](https://github.com/kaasops/vector-operator/blob/main/docs/design.md)
 - Specification [doc](https://github.com/kaasops/vector-operator/blob/main/docs/specification.md)
 - Secure credentials [doc](https://github.com/kaasops/vector-operator/blob/main/docs/secure-credential.md)

--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -3,6 +3,7 @@ Operator serves to make running Vector applications on top of Kubernetes as easy
 
 - [Installing by Helm](#installing-by-helm)
 - [Installing by Manifest](#installing-by-manifest)
+- [Upgrading](#upgrading)
 
 
 # Installing by Helm
@@ -390,6 +391,25 @@ Output
 ```
 
 You can see field `testfield`, which we add in transform section in VectorPipeline
+
+# Upgrading
+
+Upgrade the operator with Helm as usual:
+
+```sh
+helm repo update
+helm upgrade vector-operator vector-operator/vector-operator -n NAMESPACE
+```
+
+**Then update the CRDs — Helm does not upgrade them.** Helm installs the chart's `crds/` directory only on the first install and intentionally never touches it again on `helm upgrade`. New or changed CRD fields (and CRD schema fixes) therefore do not reach your cluster until you apply the CRDs yourself:
+
+```sh
+kubectl apply --server-side --force-conflicts -k "https://github.com/kaasops/vector-operator/config/crd?ref=<version-tag>"
+```
+
+Replace `<version-tag>` with the operator version you upgraded to (for example `v0.5.0`).
+
+Skipping the CRD update can break the operator in subtle ways. For example, versions up to v0.4.1 shipped CRDs that declared the pipeline hash status field as `format: int32`; Kubernetes versions that enforce integer formats (observed on v1.36) reject status updates for pipelines whose hash exceeds the int32 range, and such pipelines are silently excluded from the generated vector config. v0.5.0 fixes the schema, but only if the updated CRDs are applied.
 
 # Cleanup
 ```bash


### PR DESCRIPTION
Adds an Upgrading section to the quick-start guide (linked from the README) documenting that `helm upgrade` does not update CRDs and they must be applied manually, with the exact `kubectl apply --server-side -k` command pinned to the release tag.

Verified live: a cluster upgraded via `helm upgrade` alone keeps the old CRDs; the referenced int32 pipeline-hash issue reproduces on Kubernetes v1.36 with pre-v0.5.0 CRDs and is fixed once the updated CRDs are applied.