### PR TITLE
ci: do not move the latest image tag on pre-release tags

### DIFF
--- a/.github/workflows/build-image.yaml
+++ b/.github/workflows/build-image.yaml
@@ -37,7 +37,7 @@ jobs:
           platforms: linux/amd64,linux/arm64
           push: true
           build-args: VERSION=${{ steps.tag.outputs.TAG }}
-          tags: ${{ secrets.DOCKERHUB_USERNAME }}/${{ github.event.repository.name }}:${{ steps.tag.outputs.TAG }},${{ secrets.DOCKERHUB_USERNAME }}/${{ github.event.repository.name }}:latest
+          tags: ${{ secrets.DOCKERHUB_USERNAME }}/${{ github.event.repository.name }}:${{ steps.tag.outputs.TAG }}
 
       - name: Build event-collector image and push to Docker Hub
         uses: docker/build-push-action@v7
@@ -47,7 +47,7 @@ jobs:
           platforms: linux/amd64,linux/arm64
           push: true
           build-args: VERSION=${{ steps.tag.outputs.TAG }}
-          tags: ${{ secrets.DOCKERHUB_USERNAME }}/event-collector:${{ steps.tag.outputs.TAG }},${{ secrets.DOCKERHUB_USERNAME }}/event-collector:latest
+          tags: ${{ secrets.DOCKERHUB_USERNAME }}/event-collector:${{ steps.tag.outputs.TAG }}
 
       - name: Build checkpoint-merger image and push to Docker Hub
         uses: docker/build-push-action@v7
@@ -57,4 +57,11 @@ jobs:
           platforms: linux/amd64,linux/arm64
           push: true
           build-args: VERSION=${{ steps.tag.outputs.TAG }}
-          tags: ${{ secrets.DOCKERHUB_USERNAME }}/checkpoint-merger:${{ steps.tag.outputs.TAG }},${{ secrets.DOCKERHUB_USERNAME }}/checkpoint-merger:latest
+          tags: ${{ secrets.DOCKERHUB_USERNAME }}/checkpoint-merger:${{ steps.tag.outputs.TAG }}
+
+      - name: Tag images as latest (skipped for pre-releases)
+        if: ${{ !startsWith(github.ref_name, 'pre-') }}
+        run: |
+          docker buildx imagetools create -t ${{ secrets.DOCKERHUB_USERNAME }}/${{ github.event.repository.name }}:latest ${{ secrets.DOCKERHUB_USERNAME }}/${{ github.event.repository.name }}:${{ steps.tag.outputs.TAG }}
+          docker buildx imagetools create -t ${{ secrets.DOCKERHUB_USERNAME }}/event-collector:latest ${{ secrets.DOCKERHUB_USERNAME }}/event-collector:${{ steps.tag.outputs.TAG }}
+          docker buildx imagetools create -t ${{ secrets.DOCKERHUB_USERNAME }}/checkpoint-merger:latest ${{ secrets.DOCKERHUB_USERNAME }}/checkpoint-merger:${{ steps.tag.outputs.TAG }}


### PR DESCRIPTION
Currently a `pre-v*` tag push rebuilds all three images and also overwrites `:latest` on Docker Hub, so users installing without a pinned version get the pre-release. This change makes the build steps push only the version tag, and adds a follow-up step that re-tags the pushed images as `:latest` via `docker buildx imagetools create` (a registry-level manifest copy, multi-arch preserved, no rebuild) — skipped when the tag starts with `pre-`.

Workflow passes actionlint; the pre-release path will be exercised by the upcoming `pre-v0.5.0` tag.