### PR TITLE
fix: VectorSinkFailing alert never fires for sinks with transport-only or 5xx-only failures

### DIFF
--- a/helm/charts/vector-operator/templates/prometheusrule.yaml
+++ b/helm/charts/vector-operator/templates/prometheusrule.yaml
@@ -44,11 +44,20 @@ spec:
         # failures (errors_total: refused/DNS/TLS/timeout) and error responses
         # (responses_total 5xx/429, which are retried, not counted as errors). HTTP-based
         # sinks only; component_id also covers any HTTP-based source (kubernetes_logs is not).
+        # Vector registers counters lazily, so a sink can have only one of the two failure
+        # metrics; each addend is padded with `or 0 *` over requests_sent, or adding an
+        # empty vector would drop the sink from the result and mute the alert.
         - alert: VectorSinkFailing
           expr: |-
             (
-              sum by (pod, component_id) (rate(vector_http_client_errors_total[{{ .Values.prometheusRule.window }}]))
-              + sum by (pod, component_id) (rate(vector_http_client_responses_total{status=~"5..|429"}[{{ .Values.prometheusRule.window }}]))
+              (
+                sum by (pod, component_id) (rate(vector_http_client_errors_total[{{ .Values.prometheusRule.window }}]))
+                or 0 * sum by (pod, component_id) (rate(vector_http_client_requests_sent_total[{{ .Values.prometheusRule.window }}]))
+              )
+              + (
+                sum by (pod, component_id) (rate(vector_http_client_responses_total{status=~"5..|429"}[{{ .Values.prometheusRule.window }}]))
+                or 0 * sum by (pod, component_id) (rate(vector_http_client_requests_sent_total[{{ .Values.prometheusRule.window }}]))
+              )
             )
             / sum by (pod, component_id) (rate(vector_http_client_requests_sent_total[{{ .Values.prometheusRule.window }}]))
             > 0.5


### PR DESCRIPTION
The VectorSinkFailing expression adds two independent aggregations: transport failures from vector_http_client_errors_total and error responses from vector_http_client_responses_total{status=~"5..|429"}. Vector registers counters lazily, so a sink that fails only at the transport level (connection refused, DNS, timeout) has no responses series for the 5xx matcher, and a sink that only receives 5xx/429 has no errors series. In PromQL, adding a vector to an empty vector produces an empty result, so in both cases the sink drops out of the expression and the alert never fires, even at a 100% failure rate. A dead endpoint that refuses connections is exactly the transport-only case.

The fix pads each addend with `or 0 * sum by (pod, component_id) (rate(vector_http_client_requests_sent_total[...]))`, so both sides of the addition always carry the full set of (pod, component_id) present in the denominator. A failing sink now yields its true failure ratio, a healthy sink yields 0, and an idle sink evaluates to 0/0 = NaN and is filtered by the threshold.