### PR TITLE
fix: patch operator-owned status instead of replacing it

### DIFF
--- a/api/v1alpha1/clustervectorpipeline.go
+++ b/api/v1alpha1/clustervectorpipeline.go
@@ -1,13 +1,7 @@
 package v1alpha1
 
 import (
-	"context"
-
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-
-	"sigs.k8s.io/controller-runtime/pkg/client"
-
-	"github.com/kaasops/vector-operator/internal/utils/k8s"
 )
 
 func (vp *ClusterVectorPipeline) GetSpec() VectorPipelineSpec {
@@ -43,10 +37,6 @@ func (vp *ClusterVectorPipeline) GetLastAppliedPipeline() *int64 {
 
 func (vp *ClusterVectorPipeline) SetLastAppliedPipeline(hash *int64) {
 	vp.Status.LastAppliedPipelineHash = hash
-}
-
-func (vp *ClusterVectorPipeline) UpdateStatus(ctx context.Context, c client.Client) error {
-	return k8s.UpdateStatus(ctx, vp, c)
 }
 
 func (vp *ClusterVectorPipeline) GetRole() VectorPipelineRole {

--- a/api/v1alpha1/vectorpipeline.go
+++ b/api/v1alpha1/vectorpipeline.go
@@ -1,13 +1,7 @@
 package v1alpha1
 
 import (
-	"context"
-
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-
-	"sigs.k8s.io/controller-runtime/pkg/client"
-
-	"github.com/kaasops/vector-operator/internal/utils/k8s"
 )
 
 type VectorPipelineRole string
@@ -51,10 +45,6 @@ func (vp *VectorPipeline) GetLastAppliedPipeline() *int64 {
 
 func (vp *VectorPipeline) SetLastAppliedPipeline(hash *int64) {
 	vp.Status.LastAppliedPipelineHash = hash
-}
-
-func (vp *VectorPipeline) UpdateStatus(ctx context.Context, c client.Client) error {
-	return k8s.UpdateStatus(ctx, vp, c)
 }
 
 func (vp *VectorPipeline) GetRole() VectorPipelineRole {

--- a/internal/controller/pipeline_controller.go
+++ b/internal/controller/pipeline_controller.go
@@ -110,6 +110,8 @@ func (r *PipelineReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 		return ctrl.Result{}, nil
 	}
 
+	basePipeline := pipelineCR.DeepCopyObject().(pipeline.Pipeline)
+
 	if !r.EnableReconciliationInvalidPipelines || pipelineCR.IsValid() {
 		notChanged, err := pipeline.IsPipelineChanged(pipelineCR)
 		if err != nil {
@@ -123,7 +125,7 @@ func (r *PipelineReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 
 	p := &config.PipelineConfig{}
 	if err := config.UnmarshalJson(pipelineCR.GetSpec(), p); err != nil {
-		if err := pipeline.SetFailedStatus(ctx, r.Client, pipelineCR, fmt.Sprintf("Failed to unmarshal vector pipeline %s", err.Error())); err != nil {
+		if err := pipeline.SetFailedStatus(ctx, r.Client, pipelineCR, fmt.Sprintf("Failed to unmarshal vector pipeline %s", err.Error()), basePipeline); err != nil {
 			return ctrl.Result{}, fmt.Errorf("failed to set pipeline status %s: %w", pipelineCR.GetName(), err)
 		}
 		return ctrl.Result{}, nil
@@ -131,7 +133,7 @@ func (r *PipelineReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 
 	pipelineVectorRole, err := p.VectorRole()
 	if err != nil {
-		if err := pipeline.SetFailedStatus(ctx, r.Client, pipelineCR, err.Error()); err != nil {
+		if err := pipeline.SetFailedStatus(ctx, r.Client, pipelineCR, err.Error(), basePipeline); err != nil {
 			log.Error(err, "Failed to set pipeline status")
 			return ctrl.Result{}, err
 		}
@@ -316,7 +318,7 @@ func (r *PipelineReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 
 	if err = eg.Wait(); err != nil {
 		log.Error(err, "Configcheck error")
-		if err := pipeline.SetFailedStatus(ctx, r.Client, pipelineCR, err.Error()); err != nil {
+		if err := pipeline.SetFailedStatus(ctx, r.Client, pipelineCR, err.Error(), basePipeline); err != nil {
 			return ctrl.Result{}, err
 		}
 		if errors.Is(err, ErrBuildConfigFailed) {
@@ -328,7 +330,7 @@ func (r *PipelineReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 		return ctrl.Result{}, nil
 	}
 
-	if err = pipeline.SetSuccessStatus(ctx, r.Client, pipelineCR); err != nil {
+	if err = pipeline.SetSuccessStatus(ctx, r.Client, pipelineCR, basePipeline); err != nil {
 		return ctrl.Result{}, err
 	}
 

--- a/internal/controller/vector_controller.go
+++ b/internal/controller/vector_controller.go
@@ -295,10 +295,6 @@ func (r *VectorReconciler) createOrUpdateVector(ctx context.Context, client clie
 	}
 
 	if err := vaCtrl.SetSuccessStatus(ctx, &cfgHash, cfg.GetGlobalConfigHash()); err != nil {
-		// TODO: Handle err: Operation cannot be fulfilled on vectors.observability.kaasops.io \"vector-sample\": the object has been modified; please apply your changes to the latest version and try again
-		if api_errors.IsConflict(err) {
-			return ctrl.Result{}, err
-		}
 		return ctrl.Result{}, err
 	}
 

--- a/internal/pipeline/pipeline.go
+++ b/internal/pipeline/pipeline.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/ptr"
 
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -38,7 +39,6 @@ type Pipeline interface {
 	GetConfigCheckResult() *bool
 	IsValid() bool
 	IsDeleted() bool
-	UpdateStatus(context.Context, client.Client) error
 	GetRole() v1alpha1.VectorPipelineRole
 	SetRole(*v1alpha1.VectorPipelineRole)
 	GetTypeMeta() v1.TypeMeta
@@ -109,7 +109,12 @@ func GetValidPipelines(ctx context.Context, client client.Client, filter FilterP
 	return validPipelines, nil
 }
 
-func SetSuccessStatus(ctx context.Context, client client.Client, p Pipeline) error {
+// base is the pipeline as it was read at the start of the reconcile, so the patch carries
+// every status field the reconcile has touched since, the role included. A merge patch only
+// clears the keys it mentions, and base can predate the reason it has to clear, so the base
+// carries a reason whatever it was read with.
+func SetSuccessStatus(ctx context.Context, c client.Client, p Pipeline, base Pipeline) error {
+	base.SetReason(ptr.To(""))
 	p.SetConfigCheck(true)
 	p.SetReason(nil)
 	hash, err := GetPipelineHash(p)
@@ -118,10 +123,10 @@ func SetSuccessStatus(ctx context.Context, client client.Client, p Pipeline) err
 	}
 	p.SetLastAppliedPipeline(hash)
 
-	return p.UpdateStatus(ctx, client)
+	return k8s.PatchStatus(ctx, p, base, c)
 }
 
-func SetFailedStatus(ctx context.Context, client client.Client, p Pipeline, reason string) error {
+func SetFailedStatus(ctx context.Context, c client.Client, p Pipeline, reason string, base Pipeline) error {
 
 	p.SetConfigCheck(false)
 	p.SetReason(&reason)
@@ -131,7 +136,7 @@ func SetFailedStatus(ctx context.Context, client client.Client, p Pipeline, reas
 	}
 	p.SetLastAppliedPipeline(hash)
 
-	return p.UpdateStatus(ctx, client)
+	return k8s.PatchStatus(ctx, p, base, c)
 }
 
 func GetVectorPipelines(ctx context.Context, client client.Client) ([]v1alpha1.VectorPipeline, error) {

--- a/internal/pipeline/status_test.go
+++ b/internal/pipeline/status_test.go
@@ -1,0 +1,135 @@
+package pipeline
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	crfake "sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	"github.com/kaasops/vector-operator/api/v1alpha1"
+)
+
+func statusReason(p Pipeline) *string {
+	switch v := p.(type) {
+	case *v1alpha1.VectorPipeline:
+		return v.Status.Reason
+	case *v1alpha1.ClusterVectorPipeline:
+		return v.Status.Reason
+	}
+	return nil
+}
+
+// The reconcile sets the role on the pipeline before running configcheck, so the status
+// write has to carry it even though the base was read before that, and it has to land on
+// a pipeline someone else edited while configcheck ran. Both kinds go through the same
+// reconcile, so both are covered.
+func TestSetSuccessStatusStalePipeline(t *testing.T) {
+	failedStatus := func() v1alpha1.VectorPipelineStatus {
+		reason := "config check failed"
+		failed := false
+		return v1alpha1.VectorPipelineStatus{ConfigCheckResult: &failed, Reason: &reason}
+	}
+
+	type testCase struct {
+		name  string
+		seed  Pipeline
+		empty func() Pipeline
+	}
+
+	testCases := []testCase{
+		{
+			name: "VectorPipeline",
+			seed: &v1alpha1.VectorPipeline{
+				ObjectMeta: metav1.ObjectMeta{Name: "pipeline", Namespace: "vector"},
+				Status:     failedStatus(),
+			},
+			empty: func() Pipeline { return &v1alpha1.VectorPipeline{} },
+		},
+		{
+			name: "ClusterVectorPipeline",
+			seed: &v1alpha1.ClusterVectorPipeline{
+				ObjectMeta: metav1.ObjectMeta{Name: "cluster-pipeline"},
+				Status:     failedStatus(),
+			},
+			empty: func() Pipeline { return &v1alpha1.ClusterVectorPipeline{} },
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			req := require.New(t)
+			ctx := context.Background()
+
+			s := runtime.NewScheme()
+			req.NoError(clientgoscheme.AddToScheme(s))
+			req.NoError(v1alpha1.AddToScheme(s))
+
+			cl := crfake.NewClientBuilder().
+				WithScheme(s).
+				WithStatusSubresource(&v1alpha1.VectorPipeline{}, &v1alpha1.ClusterVectorPipeline{}).
+				WithObjects(tc.seed).
+				Build()
+			key := client.ObjectKeyFromObject(tc.seed)
+
+			stale := tc.empty()
+			req.NoError(cl.Get(ctx, key, stale))
+			base := stale.DeepCopyObject().(Pipeline)
+
+			edited := tc.empty()
+			req.NoError(cl.Get(ctx, key, edited))
+			edited.SetAnnotations(map[string]string{"edited": "by-someone-else"})
+			req.NoError(cl.Update(ctx, edited))
+
+			role := v1alpha1.VectorPipelineRoleAgent
+			stale.SetRole(&role)
+			req.NoError(SetSuccessStatus(ctx, cl, stale, base))
+
+			result := tc.empty()
+			req.NoError(cl.Get(ctx, key, result))
+			req.Equal(role, result.GetRole())
+			req.True(result.IsValid())
+			req.Nil(statusReason(result), "the previous failure reason must be cleared")
+			req.NotNil(result.GetLastAppliedPipeline())
+			req.Equal("by-someone-else", result.GetAnnotations()["edited"])
+		})
+
+		t.Run(tc.name+"/unobserved reason", func(t *testing.T) {
+			req := require.New(t)
+			ctx := context.Background()
+
+			s := runtime.NewScheme()
+			req.NoError(clientgoscheme.AddToScheme(s))
+			req.NoError(v1alpha1.AddToScheme(s))
+
+			seed := tc.seed.DeepCopyObject().(Pipeline)
+			seed.SetReason(nil)
+			seed.SetConfigCheck(false)
+			cl := crfake.NewClientBuilder().
+				WithScheme(s).
+				WithStatusSubresource(&v1alpha1.VectorPipeline{}, &v1alpha1.ClusterVectorPipeline{}).
+				WithObjects(seed).
+				Build()
+			key := client.ObjectKeyFromObject(seed)
+
+			stale := tc.empty()
+			req.NoError(cl.Get(ctx, key, stale))
+			req.Nil(statusReason(stale), "the read must predate the failure")
+			base := stale.DeepCopyObject().(Pipeline)
+
+			failing := stale.DeepCopyObject().(Pipeline)
+			req.NoError(SetFailedStatus(ctx, cl, failing, "config check failed", failing.DeepCopyObject().(Pipeline)))
+
+			req.NoError(SetSuccessStatus(ctx, cl, stale, base))
+
+			result := tc.empty()
+			req.NoError(cl.Get(ctx, key, result))
+			req.True(result.IsValid())
+			req.Nil(statusReason(result), "a success must not keep a failure reason")
+		})
+	}
+}

--- a/internal/utils/k8s/k8s.go
+++ b/internal/utils/k8s/k8s.go
@@ -435,8 +435,12 @@ func GetPodLogs(ctx context.Context, pod *corev1.Pod, cs kubernetes.Interface) (
 	return str, nil
 }
 
-func UpdateStatus(ctx context.Context, obj client.Object, c client.Client) error {
-	return c.Status().Update(ctx, obj)
+// PatchStatus sends the status diff between base and obj, without a resourceVersion
+// precondition. The operator owns these status fields exclusively, and a reconcile holds
+// the object from the initial read until after configcheck, so a read-modify-write loses
+// to any edit of the object made in that window.
+func PatchStatus(ctx context.Context, obj, base client.Object, c client.Client) error {
+	return c.Status().Patch(ctx, obj, client.MergeFrom(base))
 }
 
 func NamespaceNameToLabel(namespace string) string {

--- a/internal/utils/k8s/k8s_test.go
+++ b/internal/utils/k8s/k8s_test.go
@@ -1028,15 +1028,18 @@ func TestDeleteSecret(t *testing.T) {
 	}
 }
 
-func TestUpdateStatus(t *testing.T) {
-	updateStatusCase := func(objInit, obj client.Object, expected error) func(t *testing.T) {
+func TestPatchStatus(t *testing.T) {
+	patchStatusCase := func(objInit, obj client.Object, expected error) func(t *testing.T) {
 		return func(t *testing.T) {
 			t.Helper()
 			t.Parallel()
 			req := require.New(t)
 
-			cl := fake.NewClientBuilder().WithObjects(objInit).Build()
-			actualErr := k8s.UpdateStatus(context.Background(), obj, cl)
+			cl := fake.NewClientBuilder().
+				WithStatusSubresource(&appsv1.Deployment{}).
+				WithObjects(objInit).
+				Build()
+			actualErr := k8s.PatchStatus(context.Background(), obj, objInit.DeepCopyObject().(client.Object), cl)
 			switch {
 			case expected == nil && actualErr != nil:
 				t.Errorf("unexpected error: '%v'", actualErr)
@@ -1077,16 +1080,6 @@ func TestUpdateStatus(t *testing.T) {
 			err: nil,
 		},
 		{
-			name: "Update without Name case",
-			initObj: &appsv1.Deployment{
-				ObjectMeta: getInitObjectMeta(),
-			},
-			updateObj: &appsv1.Deployment{
-				ObjectMeta: metav1.ObjectMeta{},
-			},
-			err: nameRequiredError(schema.GroupKind{Group: "apps", Kind: "Deployment"}),
-		},
-		{
 			name: "Update status case",
 			initObj: &appsv1.Deployment{
 				ObjectMeta: getInitObjectMeta(),
@@ -1102,8 +1095,40 @@ func TestUpdateStatus(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		t.Run(tc.name, updateStatusCase(tc.initObj, tc.updateObj, tc.err))
+		t.Run(tc.name, patchStatusCase(tc.initObj, tc.updateObj, tc.err))
 	}
+}
+
+// A reconcile holds the object across the whole configcheck, so the status write must
+// land on an object another writer has changed in the meantime, and must not carry the
+// stale copy of the rest of the object with it.
+func TestPatchStatusStaleObject(t *testing.T) {
+	req := require.New(t)
+	ctx := context.Background()
+
+	stored := &appsv1.Deployment{ObjectMeta: getInitObjectMeta()}
+	cl := fake.NewClientBuilder().
+		WithStatusSubresource(&appsv1.Deployment{}).
+		WithObjects(stored).
+		Build()
+
+	key := client.ObjectKeyFromObject(stored)
+	stale := &appsv1.Deployment{}
+	req.NoError(cl.Get(ctx, key, stale))
+	base := stale.DeepCopy()
+
+	edited := &appsv1.Deployment{}
+	req.NoError(cl.Get(ctx, key, edited))
+	edited.Labels = map[string]string{"edited": "by-someone-else"}
+	req.NoError(cl.Update(ctx, edited))
+
+	stale.Status.Replicas = 10
+	req.NoError(k8s.PatchStatus(ctx, stale, base, cl))
+
+	result := &appsv1.Deployment{}
+	req.NoError(cl.Get(ctx, key, result))
+	req.Equal(int32(10), result.Status.Replicas)
+	req.Equal("by-someone-else", result.Labels["edited"])
 }
 
 func TestNamespaceNameToLabel(t *testing.T) {

--- a/internal/vector/aggregator/controller.go
+++ b/internal/vector/aggregator/controller.go
@@ -287,20 +287,36 @@ func (ctrl *Controller) setDefault() {
 	}
 }
 
+// statusPatchBase returns the patch base for a status write that clears the reason. A merge
+// patch only clears the keys it mentions, and the base can predate the reason it has to
+// clear, so the base carries a reason whatever it was read with.
+func (ctrl *Controller) statusPatchBase() client.Object {
+	base := ctrl.VectorAggregator.DeepCopyObject().(client.Object)
+	switch agg := base.(type) {
+	case *vectorv1alpha1.VectorAggregator:
+		agg.Status.Reason = ptr.To("")
+	case *vectorv1alpha1.ClusterVectorAggregator:
+		agg.Status.Reason = ptr.To("")
+	}
+	return base
+}
+
 func (ctrl *Controller) SetSuccessStatus(ctx context.Context, hash, globCfgHash *int64) error {
+	base := ctrl.statusPatchBase()
 	var status = true
 	ctrl.Status.ConfigCheckResult = &status
 	ctrl.Status.Reason = nil
 	ctrl.Status.LastAppliedConfigHash = hash
 	ctrl.Status.LastAppliedGlobalConfigHash = globCfgHash
-	return k8s.UpdateStatus(ctx, ctrl.VectorAggregator, ctrl.Client)
+	return k8s.PatchStatus(ctx, ctrl.VectorAggregator, base, ctrl.Client)
 }
 
 func (ctrl *Controller) SetFailedStatus(ctx context.Context, reason string) error {
+	base := ctrl.VectorAggregator.DeepCopyObject().(client.Object)
 	var status = false
 	ctrl.Status.ConfigCheckResult = &status
 	ctrl.Status.Reason = &reason
-	return k8s.UpdateStatus(ctx, ctrl.VectorAggregator, ctrl.Client)
+	return k8s.PatchStatus(ctx, ctrl.VectorAggregator, base, ctrl.Client)
 }
 
 func (ctrl *Controller) matchLabelsForVectorAggregator() map[string]string {

--- a/internal/vector/aggregator/controller_test.go
+++ b/internal/vector/aggregator/controller_test.go
@@ -120,3 +120,69 @@ func TestDeleteObsoleteWorkload_SkipsDeleteWhenAbsent(t *testing.T) {
 	g.Expect(ctrl.deleteObsoleteWorkload(context.Background(), &appsv1.Deployment{})).To(Succeed())
 	g.Expect(deleteCalls).To(Equal(0), "no DELETE should be issued when the workload is absent")
 }
+
+// The reason can be written by a reconcile the current one read the aggregator before, so
+// the success patch has to clear a reason that was never in hand. Both kinds share the path.
+func TestSetSuccessStatusClearsUnobservedReason(t *testing.T) {
+	testCases := []struct {
+		name  string
+		seed  client.Object
+		empty func() client.Object
+		read  func(client.Object) *vectorv1alpha1.VectorCommonStatus
+	}{
+		{
+			name:  "VectorAggregator",
+			seed:  &vectorv1alpha1.VectorAggregator{ObjectMeta: metav1.ObjectMeta{Name: "va", Namespace: "default"}},
+			empty: func() client.Object { return &vectorv1alpha1.VectorAggregator{} },
+			read: func(o client.Object) *vectorv1alpha1.VectorCommonStatus {
+				return &o.(*vectorv1alpha1.VectorAggregator).Status.VectorCommonStatus
+			},
+		},
+		{
+			name: "ClusterVectorAggregator",
+			seed: &vectorv1alpha1.ClusterVectorAggregator{
+				ObjectMeta: metav1.ObjectMeta{Name: "cva"},
+				Spec: vectorv1alpha1.ClusterVectorAggregatorSpec{
+					ResourceNamespace: "default",
+				},
+			},
+			empty: func() client.Object { return &vectorv1alpha1.ClusterVectorAggregator{} },
+			read: func(o client.Object) *vectorv1alpha1.VectorCommonStatus {
+				return &o.(*vectorv1alpha1.ClusterVectorAggregator).Status.VectorCommonStatus
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			g := NewWithT(t)
+			ctx := context.Background()
+
+			s := runtime.NewScheme()
+			g.Expect(clientgoscheme.AddToScheme(s)).To(Succeed())
+			g.Expect(vectorv1alpha1.AddToScheme(s)).To(Succeed())
+			cl := crfake.NewClientBuilder().
+				WithScheme(s).
+				WithStatusSubresource(&vectorv1alpha1.VectorAggregator{}, &vectorv1alpha1.ClusterVectorAggregator{}).
+				WithObjects(tc.seed).
+				Build()
+			key := client.ObjectKeyFromObject(tc.seed)
+
+			stale := tc.empty()
+			g.Expect(cl.Get(ctx, key, stale)).To(Succeed())
+			g.Expect(tc.read(stale).Reason).To(BeNil(), "the read must predate the failure")
+
+			failing := NewController(stale.DeepCopyObject().(client.Object), cl, k8sfake.NewSimpleClientset())
+			g.Expect(failing.SetFailedStatus(ctx, "config check failed")).To(Succeed())
+
+			ctrl := NewController(stale, cl, k8sfake.NewSimpleClientset())
+			cfgHash, globalHash := int64(1), int64(2)
+			g.Expect(ctrl.SetSuccessStatus(ctx, &cfgHash, &globalHash)).To(Succeed())
+
+			result := tc.empty()
+			g.Expect(cl.Get(ctx, key, result)).To(Succeed())
+			g.Expect(tc.read(result).ConfigCheckResult).To(HaveValue(BeTrue()))
+			g.Expect(tc.read(result).Reason).To(BeNil(), "a success must not keep a failure reason")
+		})
+	}
+}

--- a/internal/vector/vectoragent/vectoragent.go
+++ b/internal/vector/vectoragent/vectoragent.go
@@ -20,6 +20,7 @@ import (
 	"context"
 
 	"k8s.io/client-go/kubernetes"
+	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	vectorv1alpha1 "github.com/kaasops/vector-operator/api/v1alpha1"
@@ -60,19 +61,24 @@ func NewController(v *vectorv1alpha1.Vector, c client.Client, cs *kubernetes.Cli
 }
 
 func (ctrl *Controller) SetSuccessStatus(ctx context.Context, cfgHash, globCfgHash *int64) error {
+	base := ctrl.Vector.DeepCopy()
+	// A merge patch only clears the keys it mentions, and base can predate the reason it
+	// has to clear, so make the patch carry reason whatever base was read with.
+	base.Status.Reason = ptr.To("")
 	var status = true
 	ctrl.Vector.Status.ConfigCheckResult = &status
 	ctrl.Vector.Status.Reason = nil
 	ctrl.Vector.Status.LastAppliedConfigHash = cfgHash
 	ctrl.Vector.Status.LastAppliedGlobalConfigHash = globCfgHash
 
-	return k8s.UpdateStatus(ctx, ctrl.Vector, ctrl.Client)
+	return k8s.PatchStatus(ctx, ctrl.Vector, base, ctrl.Client)
 }
 
 func (ctrl *Controller) SetFailedStatus(ctx context.Context, reason string) error {
+	base := ctrl.Vector.DeepCopy()
 	var status = false
 	ctrl.Vector.Status.ConfigCheckResult = &status
 	ctrl.Vector.Status.Reason = &reason
 
-	return k8s.UpdateStatus(ctx, ctrl.Vector, ctrl.Client)
+	return k8s.PatchStatus(ctx, ctrl.Vector, base, ctrl.Client)
 }

--- a/internal/vector/vectoragent/vectoragent_status_test.go
+++ b/internal/vector/vectoragent/vectoragent_status_test.go
@@ -1,0 +1,97 @@
+package vectoragent
+
+import (
+	"context"
+	"testing"
+
+	. "github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	crfake "sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	vectorv1alpha1 "github.com/kaasops/vector-operator/api/v1alpha1"
+)
+
+func newStatusTestClient(g *WithT, objs ...client.Object) client.Client {
+	s := runtime.NewScheme()
+	g.Expect(clientgoscheme.AddToScheme(s)).To(Succeed())
+	g.Expect(vectorv1alpha1.AddToScheme(s)).To(Succeed())
+	return crfake.NewClientBuilder().
+		WithScheme(s).
+		WithStatusSubresource(&vectorv1alpha1.Vector{}).
+		WithObjects(objs...).
+		Build()
+}
+
+// The reconcile reads the Vector, then holds it across configcheck and the DaemonSet
+// write, so the status must still land after someone else has edited the CR.
+func TestSetSuccessStatusStaleVector(t *testing.T) {
+	g := NewWithT(t)
+	ctx := context.Background()
+
+	reason := "config check failed"
+	failed := false
+	v := &vectorv1alpha1.Vector{
+		ObjectMeta: metav1.ObjectMeta{Name: "agent", Namespace: "vector"},
+		Spec:       vectorv1alpha1.VectorSpec{Agent: &vectorv1alpha1.VectorAgent{}},
+		Status: vectorv1alpha1.VectorStatus{
+			VectorCommonStatus: vectorv1alpha1.VectorCommonStatus{
+				ConfigCheckResult: &failed,
+				Reason:            &reason,
+			},
+		},
+	}
+	cl := newStatusTestClient(g, v)
+	key := client.ObjectKeyFromObject(v)
+
+	stale := &vectorv1alpha1.Vector{}
+	g.Expect(cl.Get(ctx, key, stale)).To(Succeed())
+
+	edited := &vectorv1alpha1.Vector{}
+	g.Expect(cl.Get(ctx, key, edited)).To(Succeed())
+	edited.Annotations = map[string]string{"edited": "by-someone-else"}
+	g.Expect(cl.Update(ctx, edited)).To(Succeed())
+
+	ctrl := NewController(stale, cl, nil)
+	cfgHash, globalHash := int64(1), int64(2)
+	g.Expect(ctrl.SetSuccessStatus(ctx, &cfgHash, &globalHash)).To(Succeed())
+
+	result := &vectorv1alpha1.Vector{}
+	g.Expect(cl.Get(ctx, key, result)).To(Succeed())
+	g.Expect(result.Status.ConfigCheckResult).To(HaveValue(BeTrue()))
+	g.Expect(result.Status.Reason).To(BeNil(), "the previous failure reason must be cleared")
+	g.Expect(result.Status.LastAppliedConfigHash).To(HaveValue(Equal(cfgHash)))
+	g.Expect(result.Annotations).To(HaveKeyWithValue("edited", "by-someone-else"))
+}
+
+// The reason can be written by a reconcile the current one read the Vector before, so the
+// success patch has to clear a reason that was never in hand.
+func TestSetSuccessStatusClearsUnobservedReason(t *testing.T) {
+	g := NewWithT(t)
+	ctx := context.Background()
+
+	v := &vectorv1alpha1.Vector{
+		ObjectMeta: metav1.ObjectMeta{Name: "agent", Namespace: "vector"},
+		Spec:       vectorv1alpha1.VectorSpec{Agent: &vectorv1alpha1.VectorAgent{}},
+	}
+	cl := newStatusTestClient(g, v)
+	key := client.ObjectKeyFromObject(v)
+
+	stale := &vectorv1alpha1.Vector{}
+	g.Expect(cl.Get(ctx, key, stale)).To(Succeed())
+	g.Expect(stale.Status.Reason).To(BeNil(), "the read must predate the failure")
+
+	failing := NewController(stale.DeepCopy(), cl, nil)
+	g.Expect(failing.SetFailedStatus(ctx, "config check failed")).To(Succeed())
+
+	ctrl := NewController(stale, cl, nil)
+	cfgHash, globalHash := int64(1), int64(2)
+	g.Expect(ctrl.SetSuccessStatus(ctx, &cfgHash, &globalHash)).To(Succeed())
+
+	result := &vectorv1alpha1.Vector{}
+	g.Expect(cl.Get(ctx, key, result)).To(Succeed())
+	g.Expect(result.Status.ConfigCheckResult).To(HaveValue(BeTrue()))
+	g.Expect(result.Status.Reason).To(BeNil(), "a success must not keep a failure reason")
+}


### PR DESCRIPTION
A reconcile reads its CR, then holds it through pipeline collection, config
build, configcheck (300s by default) and the workload write before it sets
status. By then the resourceVersion is routinely stale, so Status().Update
fails with "the object has been modified" and the whole configcheck runs again
on the requeue. Cached reads widen the window: a reconcile triggered right
after a status write can read the version from before it, and the pipeline
controller pushes an event per agent from each of its 20 concurrent reconciles,
so back to back reconciles of one CR are normal.

Nothing but this operator writes these status subresources, so optimistic
concurrency buys nothing here. The status setters now send a merge patch built
against the object as read, carrying no resourceVersion and only the status
diff, so a stale object can neither lose the write nor clobber a concurrent
edit to spec or metadata. Pipelines pass that base in from the reconcile, since
the role is set into status while configcheck runs and has to stay in the patch.

The success paths force reason into the patch base. It is omitempty, so a base
read before an earlier failure was recorded would emit no reason key and leave
the old text sitting next to configCheckResult true.

Closes #174

