### PR TITLE
fix: bump go directive to 1.26.6 to clear govulncheck stdlib findings

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/kaasops/vector-operator
 
-go 1.26.5
+go 1.26.6
 
 require (
 	github.com/VictoriaMetrics/operator/api v0.73.1


### PR DESCRIPTION
`govulncheck ./...` currently fails on `main`: the Go directive pins 1.26.5, every workflow installs the toolchain with `go-version-file: go.mod`, and 1.26.5's standard library carries six vulnerabilities that the scan reaches through existing call paths (`k8s.GetPodLogs`, the event collector's `http.ListenAndServe`, the e2e framework).

All six are fixed in 1.26.6:

- [GO-2026-6218](https://pkg.go.dev/vuln/GO-2026-6218) — quadratic complexity in `net/url` `resolvePath`
- [GO-2026-6091](https://pkg.go.dev/vuln/GO-2026-6091) — JavaScript regexp context tracking in `html/template`
- [GO-2026-6090](https://pkg.go.dev/vuln/GO-2026-6090) — post-handshake message limit in `crypto/tls`
- [GO-2026-6089](https://pkg.go.dev/vuln/GO-2026-6089) — missing `ReadHeaderTimeout` on the unencrypted HTTP/2 check in `net/http`
- [GO-2026-5972](https://pkg.go.dev/vuln/GO-2026-5972) — recursion depth in `encoding/asn1`
- [GO-2026-5026](https://pkg.go.dev/vuln/GO-2026-5026) — ASCII-only Punycode labels in `golang.org/x/net/idna`

Bumping the directive to 1.26.6 makes `setup-go` install the fixed toolchain, and `govulncheck ./...` then reports `No vulnerabilities found` (verified locally on this branch; on `main` the same scan reports all six).

The published image is built `FROM golang:1.26`, which already floats to the latest patch, so this changes what CI verifies rather than what ships.
