### PR TITLE
fix: sweep configcheck orphans by age instead of process start

### DIFF
--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -207,17 +207,14 @@ func main() {
 		os.Exit(1)
 	}
 
-	// Sweep configcheck Secrets orphaned by a previous operator process (crash
-	// between creating them and the process-local deferred cleanup): nothing owns the
-	// root configcheck Secret, and with pipeline secrets the orphan can include a
-	// plaintext copy of referenced credentials. Runs under leader election; only
-	// Secrets older than this process are touched, so live configchecks are safe.
-	operatorStart := time.Now()
+	// Sweep configcheck Secrets orphaned by a dead operator process (crash between
+	// creating them and the process-local deferred cleanup): nothing owns the root
+	// configcheck Secret, and with pipeline secrets the orphan can include a plaintext
+	// copy of referenced credentials. Only Secrets older than the configcheck timeout
+	// are swept, so a check running in this process - or in the one this process is
+	// replacing during a rolling update - is never touched.
 	if err := mgr.Add(manager.RunnableFunc(func(ctx context.Context) error {
-		if err := configcheck.SweepOrphans(ctx, mgr.GetAPIReader(), mgr.GetClient(), operatorStart); err != nil {
-			setupLog.Error(err, "failed to sweep orphaned configcheck secrets")
-		}
-		<-ctx.Done()
+		configcheck.RunOrphanSweeper(ctx, mgr.GetAPIReader(), mgr.GetClient(), configCheckTimeout, configcheck.OrphanSweepInterval)
 		return nil
 	})); err != nil {
 		setupLog.Error(err, "unable to add configcheck orphan sweep")

--- a/internal/config/configcheck/configcheck.go
+++ b/internal/config/configcheck/configcheck.go
@@ -453,23 +453,40 @@ func orphanSweepLabels() labels.Selector {
 	})
 }
 
-// SweepOrphans deletes configcheck Secrets left behind by a previous operator
-// process. Nothing owns the root configcheck Secret (the pod is owned by it, not the
-// other way around), so a crash between creating it and the process-local deferred
-// cleanup strands it - and with pipeline secrets in play the orphaned
+// minOrphanAge floors the sweep window. The window is the configcheck timeout, which an
+// operator can set arbitrarily low, and a degenerate window would sweep running checks.
+// A var, not a const, so tests can exercise the sweeper on a timescale they can wait for.
+var minOrphanAge = time.Minute
+
+// OrphanSweepInterval is how often orphans are looked for once the process is running.
+const OrphanSweepInterval = time.Hour
+
+// SweepOrphans deletes configcheck Secrets left behind by a dead operator process.
+// Nothing owns the root configcheck Secret (the pod is owned by it, not the other way
+// around), so a crash between creating it and the process-local deferred cleanup
+// strands it - and with pipeline secrets in play the orphaned
 // configcheck-secret-assets child holds a plaintext copy of referenced credentials.
-// Only Secrets created before startedBefore (the current process start) are swept, so
-// configchecks racing with the sweep are never touched; the orphaned pod, if any,
+//
+// Only Secrets older than configCheckTimeout are swept. A check cannot outlive its own
+// timeout, so a younger Secret still belongs to a running one - not necessarily ours:
+// two operator processes overlap on every rolling update of the Deployment, and
+// deleting the older process' Secret garbage-collects its configcheck pod, failing the
+// check with "pod was deleted before producing a result". The orphaned pod, if any,
 // follows its root Secret via ownerRef GC.
-func SweepOrphans(ctx context.Context, reader client.Reader, c client.Client, startedBefore time.Time) error {
+func SweepOrphans(ctx context.Context, reader client.Reader, c client.Client, configCheckTimeout time.Duration) error {
 	var list corev1.SecretList
 	if err := reader.List(ctx, &list, &client.ListOptions{LabelSelector: orphanSweepLabels()}); err != nil {
 		return err
 	}
+	window := configCheckTimeout
+	if window < minOrphanAge {
+		window = minOrphanAge
+	}
+	cutoff := time.Now().Add(-window)
 	var errs []error
 	for i := range list.Items {
 		secret := &list.Items[i]
-		if !secret.CreationTimestamp.Time.Before(startedBefore) {
+		if !secret.CreationTimestamp.Time.Before(cutoff) {
 			continue
 		}
 		if err := c.Delete(ctx, secret); err != nil && !api_errors.IsNotFound(err) {
@@ -477,4 +494,26 @@ func SweepOrphans(ctx context.Context, reader client.Reader, c client.Client, st
 		}
 	}
 	return errors.Join(errs...)
+}
+
+// RunOrphanSweeper sweeps on start and then every interval until ctx is done. A single
+// pass at startup would never reach an orphan stranded moments before this process
+// started: it is younger than the window then, and nothing looks at it again. Repeating
+// lets it age into a later pass. The interval is deliberately not the window - a sweep
+// lists Secrets cluster-wide, and the label selector is applied by the API server after
+// reading them all, so it is far too expensive to repeat every few minutes.
+func RunOrphanSweeper(ctx context.Context, reader client.Reader, c client.Client, configCheckTimeout, interval time.Duration) {
+	log := log.FromContext(ctx)
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+	for {
+		if err := SweepOrphans(ctx, reader, c, configCheckTimeout); err != nil {
+			log.Error(err, "failed to sweep orphaned configcheck secrets")
+		}
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+		}
+	}
 }

--- a/internal/config/configcheck/configcheck.go
+++ b/internal/config/configcheck/configcheck.go
@@ -139,6 +139,11 @@ func (cc *ConfigCheck) Run(ctx context.Context) (reason string, err error) {
 	log := log.FromContext(ctx).WithValues("Vector ConfigCheck", cc.Initiator)
 	log.Info("================= Started ConfigCheck =================")
 
+	// The budget covers the whole check, not just the wait for its result: the root
+	// Secret is created below and its age is what the orphan sweep judges, so the check
+	// must be over by the time that age reaches ConfigCheckTimeout.
+	deadline := time.Now().Add(cc.ConfigCheckTimeout)
+
 	// A terminating namespace cannot accept new content, so the configcheck pod and
 	// secret would never be admitted and getCheckResult would block until
 	// ConfigCheckTimeout, holding the reconcile worker. Skip instead.
@@ -207,7 +212,7 @@ func (cc *ConfigCheck) Run(ctx context.Context) (reason string, err error) {
 		return "", err
 	}
 
-	reason, err = cc.getCheckResult(ctx, vectorConfigCheckPod)
+	reason, err = cc.getCheckResult(ctx, vectorConfigCheckPod, deadline)
 	if err != nil {
 		if errors.Is(err, ErrValidation) {
 			return reason, err
@@ -279,7 +284,7 @@ func unstartableReason(pod *corev1.Pod) (string, bool) {
 	return "", false
 }
 
-func (cc *ConfigCheck) getCheckResult(ctx context.Context, pod *corev1.Pod) (reason string, err error) {
+func (cc *ConfigCheck) getCheckResult(ctx context.Context, pod *corev1.Pod, deadline time.Time) (reason string, err error) {
 	log := log.FromContext(ctx).WithValues("Vector ConfigCheck", pod.Name)
 	log.Info("Trying to get configcheck result")
 
@@ -295,12 +300,12 @@ func (cc *ConfigCheck) getCheckResult(ctx context.Context, pod *corev1.Pod) (rea
 
 	defer watcher.Stop()
 
-	// One timer for the whole check, never reset: the timeout is the budget for the
-	// check, not for the gap between pod events. A pod that keeps emitting status
-	// updates would otherwise hold the reconcile worker indefinitely.
+	// What is left of the budget started in Run, never reset: the timeout bounds the
+	// check, not the gap between pod events. A pod that keeps emitting status updates
+	// would otherwise hold the reconcile worker indefinitely.
 	// (time.NewTimer rather than time.After, which leaks ~280 bytes per select
 	// iteration until it fires.)
-	timer := time.NewTimer(cc.ConfigCheckTimeout)
+	timer := time.NewTimer(time.Until(deadline))
 	defer timer.Stop()
 
 	for {

--- a/internal/config/configcheck/configcheck.go
+++ b/internal/config/configcheck/configcheck.go
@@ -294,7 +294,14 @@ func (cc *ConfigCheck) getCheckResult(ctx context.Context, pod *corev1.Pod, dead
 	log := log.FromContext(ctx).WithValues("Vector ConfigCheck", pod.Name)
 	log.Info("Trying to get configcheck result")
 
-	watcher, err := cc.ClientSet.CoreV1().Pods(cc.Namespace).Watch(ctx, metav1.ListOptions{
+	// Establishing the watch is a request of its own and belongs inside the budget:
+	// it happens before the timer exists, so a hung one would sit outside every bound.
+	// Only the request gets this context - the select below keeps the caller's ctx,
+	// where cancellation means "give up", and lets the timer produce the verdict.
+	watchCtx, cancelWatch := context.WithDeadline(ctx, deadline)
+	defer cancelWatch()
+
+	watcher, err := cc.ClientSet.CoreV1().Pods(cc.Namespace).Watch(watchCtx, metav1.ListOptions{
 		FieldSelector: fields.OneTermEqualSelector(metav1.ObjectNameField, pod.Name).String(),
 		// LabelSelector: labelsForVectorConfigCheck(),
 	})

--- a/internal/config/configcheck/configcheck.go
+++ b/internal/config/configcheck/configcheck.go
@@ -141,26 +141,32 @@ func (cc *ConfigCheck) Run(ctx context.Context) (reason string, err error) {
 
 	// The budget covers the whole check, not just the wait for its result: the root
 	// Secret is created below and its age is what the orphan sweep judges, so the check
-	// must be over by the time that age reaches ConfigCheckTimeout.
+	// must be over by the time that age reaches ConfigCheckTimeout. budgetCtx carries
+	// that deadline into every preparation call; cleanup below deliberately keeps the
+	// caller's ctx, so a check that runs out of budget still removes what it created.
+	// getCheckResult keeps the caller's ctx too - a cancelled ctx means "give up", not
+	// "the config is valid" - and bounds itself with what is left of the budget.
 	deadline := time.Now().Add(cc.ConfigCheckTimeout)
+	budgetCtx, cancelBudget := context.WithDeadline(ctx, deadline)
+	defer cancelBudget()
 
 	// A terminating namespace cannot accept new content, so the configcheck pod and
 	// secret would never be admitted and getCheckResult would block until
 	// ConfigCheckTimeout, holding the reconcile worker. Skip instead.
-	if terminating, err := cc.namespaceIsTerminating(ctx); err != nil {
+	if terminating, err := cc.namespaceIsTerminating(budgetCtx); err != nil {
 		return "", err
 	} else if terminating {
 		log.Info("Skipping ConfigCheck: namespace is terminating or gone", "namespace", cc.Namespace)
 		return "", ErrConfigcheckSkipped
 	}
 
-	if err := cc.ensureVectorConfigCheckRBAC(ctx); err != nil && !api_errors.IsAlreadyExists(err) { // TODO(aa1ex): error is silenced, is that ok?
+	if err := cc.ensureVectorConfigCheckRBAC(budgetCtx); err != nil && !api_errors.IsAlreadyExists(err) { // TODO(aa1ex): error is silenced, is that ok?
 		return "", err
 	}
 
 	cc.Hash = randStringRunes()
 
-	vectorConfigCheckSecret, err := cc.createVectorConfigCheckConfig(ctx)
+	vectorConfigCheckSecret, err := cc.createVectorConfigCheckConfig(budgetCtx)
 	if err != nil {
 		return "", err
 	}
@@ -188,7 +194,7 @@ func (cc *ConfigCheck) Run(ctx context.Context) (reason string, err error) {
 		err = errors.Join(err, cleanupErr)
 	}()
 
-	if err = k8s.CreateOrUpdateResource(ctx, vectorConfigCheckSecret, cc.Client); err != nil {
+	if err = k8s.CreateOrUpdateResource(budgetCtx, vectorConfigCheckSecret, cc.Client); err != nil {
 		return "", err
 	}
 
@@ -197,7 +203,7 @@ func (cc *ConfigCheck) Run(ctx context.Context) (reason string, err error) {
 		if err = controllerutil.SetOwnerReference(vectorConfigCheckSecret, vectorSecretAssetsSecret, cc.Client.Scheme()); err != nil {
 			return "", err
 		}
-		if err = k8s.CreateOrUpdateResource(ctx, vectorSecretAssetsSecret, cc.Client); err != nil {
+		if err = k8s.CreateOrUpdateResource(budgetCtx, vectorSecretAssetsSecret, cc.Client); err != nil {
 			return "", err
 		}
 	}
@@ -207,7 +213,7 @@ func (cc *ConfigCheck) Run(ctx context.Context) (reason string, err error) {
 		return "", err
 	}
 
-	err = k8s.CreatePod(ctx, vectorConfigCheckPod, cc.Client)
+	err = k8s.CreatePod(budgetCtx, vectorConfigCheckPod, cc.Client)
 	if err != nil {
 		return "", err
 	}

--- a/internal/config/configcheck/configcheck.go
+++ b/internal/config/configcheck/configcheck.go
@@ -295,9 +295,11 @@ func (cc *ConfigCheck) getCheckResult(ctx context.Context, pod *corev1.Pod) (rea
 
 	defer watcher.Stop()
 
-	// Use time.NewTimer instead of time.After to prevent memory leak.
-	// time.After() creates a new timer on each select iteration that won't be GC'd
-	// until it fires, causing ~280 bytes leak per iteration.
+	// One timer for the whole check, never reset: the timeout is the budget for the
+	// check, not for the gap between pod events. A pod that keeps emitting status
+	// updates would otherwise hold the reconcile worker indefinitely.
+	// (time.NewTimer rather than time.After, which leaks ~280 bytes per select
+	// iteration until it fires.)
 	timer := time.NewTimer(cc.ConfigCheckTimeout)
 	defer timer.Stop()
 
@@ -344,14 +346,6 @@ func (cc *ConfigCheck) getCheckResult(ctx context.Context, pod *corev1.Pod) (rea
 			case watch.Deleted:
 				return "", fmt.Errorf("configcheck: pod %s was deleted before producing a result", pod.Name)
 			}
-			// Reset timer after processing event to restart timeout window
-			if !timer.Stop() {
-				select {
-				case <-timer.C:
-				default:
-				}
-			}
-			timer.Reset(cc.ConfigCheckTimeout)
 		case <-ctx.Done():
 			return "", nil
 		case <-timer.C:

--- a/internal/config/configcheck/namespace_test.go
+++ b/internal/config/configcheck/namespace_test.go
@@ -20,12 +20,14 @@ import (
 	"context"
 	"errors"
 	"testing"
+	"time"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 )
 
 func newCCWithNamespace(objs ...client.Object) *ConfigCheck {
@@ -96,5 +98,50 @@ func TestRunSkipsTerminatingNamespace(t *testing.T) {
 	_, err := cc.Run(context.Background())
 	if !errors.Is(err, ErrConfigcheckSkipped) {
 		t.Fatalf("want ErrConfigcheckSkipped, got %v", err)
+	}
+}
+
+// The budget must cover the preparation calls, not just the wait for the result: the
+// root Secret is already on the cluster while the pod is being created, and its age is
+// what the orphan sweep judges. A preparation call that hangs must end the check on the
+// deadline instead of holding the reconcile worker while that Secret ages past its
+// window - and past the point where another operator process may sweep it.
+func TestRunBudgetCoversPreparationCalls(t *testing.T) {
+	scheme := runtime.NewScheme()
+	_ = corev1.AddToScheme(scheme)
+	ns := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "target"}}
+
+	hangOnPod := interceptor.Funcs{
+		Create: func(ctx context.Context, c client.WithWatch, obj client.Object, opts ...client.CreateOption) error {
+			if _, ok := obj.(*corev1.Pod); ok {
+				<-ctx.Done()
+				return ctx.Err()
+			}
+			return c.Create(ctx, obj, opts...)
+		},
+	}
+	cl := fake.NewClientBuilder().WithScheme(scheme).WithObjects(ns).
+		WithInterceptorFuncs(hangOnPod).Build()
+
+	cc := &ConfigCheck{
+		Client:             cl,
+		Namespace:          "target",
+		Name:               "agent",
+		ConfigCheckTimeout: 200 * time.Millisecond,
+	}
+
+	done := make(chan error, 1)
+	go func() {
+		_, err := cc.Run(context.Background())
+		done <- err
+	}()
+
+	select {
+	case err := <-done:
+		if !errors.Is(err, context.DeadlineExceeded) {
+			t.Fatalf("want the budget to end the check, got %v", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("Run outlived its budget while a preparation call hung")
 	}
 }

--- a/internal/config/configcheck/orphan_sweep_test.go
+++ b/internal/config/configcheck/orphan_sweep_test.go
@@ -49,31 +49,102 @@ func configCheckSecret(name string, created time.Time, labeled bool) *corev1.Sec
 }
 
 // A crash between creating configcheck Secrets and the process-local deferred
-// cleanup leaves them orphaned forever (nothing owns the root Secret). The startup
-// sweep must delete exactly the labeled Secrets from before this process started -
-// never a concurrently running configcheck's (created after start), never an
-// unrelated Secret.
+// cleanup leaves them orphaned forever (nothing owns the root Secret). The sweep
+// must delete exactly the labeled Secrets older than the configcheck timeout -
+// never an unrelated Secret.
 func TestSweepOrphansDeletesOnlyStaleConfigCheckSecrets(t *testing.T) {
-	start := time.Now()
-	stale := configCheckSecret("configcheck-old", start.Add(-time.Hour), true)
-	staleAssets := configCheckSecret("configcheck-secret-assets-old", start.Add(-time.Hour), true)
-	fresh := configCheckSecret("configcheck-live", start.Add(time.Minute), true)
-	unrelated := configCheckSecret("user-creds", start.Add(-time.Hour), false)
+	now := time.Now()
+	stale := configCheckSecret("configcheck-old", now.Add(-time.Hour), true)
+	staleAssets := configCheckSecret("configcheck-secret-assets-old", now.Add(-time.Hour), true)
+	unrelated := configCheckSecret("user-creds", now.Add(-time.Hour), false)
 
 	scheme := runtime.NewScheme()
 	require.NoError(t, corev1.AddToScheme(scheme))
 	cl := crfake.NewClientBuilder().WithScheme(scheme).
-		WithObjects(stale, staleAssets, fresh, unrelated).Build()
+		WithObjects(stale, staleAssets, unrelated).Build()
 
-	require.NoError(t, SweepOrphans(context.Background(), cl, cl, start))
+	require.NoError(t, SweepOrphans(context.Background(), cl, cl, 5*time.Minute))
 
 	for _, gone := range []string{"configcheck-old", "configcheck-secret-assets-old"} {
 		err := cl.Get(context.Background(), types.NamespacedName{Namespace: "vector", Name: gone}, &corev1.Secret{})
 		require.True(t, api_errors.IsNotFound(err), "%s must be swept", gone)
 	}
-	for _, kept := range []string{"configcheck-live", "user-creds"} {
+	require.NoError(t,
+		cl.Get(context.Background(), types.NamespacedName{Namespace: "vector", Name: "user-creds"}, &corev1.Secret{}),
+		"an unrelated Secret must survive the sweep")
+}
+
+// A configcheck cannot outlive its own timeout, so a younger Secret always belongs
+// to a running check - including one owned by another operator process. Two processes
+// overlap on every rolling update of the operator Deployment (the chart sets no
+// strategy and does not enable leader election), and sweeping the older process'
+// live Secret garbage-collects its pod: the check then fails with "pod was deleted
+// before producing a result" and the pipeline is left invalid.
+func TestSweepOrphansKeepsConfigChecksYoungerThanTimeout(t *testing.T) {
+	now := time.Now()
+	live := configCheckSecret("configcheck-live", now.Add(-30*time.Second), true)
+	liveAssets := configCheckSecret("configcheck-secret-assets-live", now.Add(-30*time.Second), true)
+
+	scheme := runtime.NewScheme()
+	require.NoError(t, corev1.AddToScheme(scheme))
+	cl := crfake.NewClientBuilder().WithScheme(scheme).WithObjects(live, liveAssets).Build()
+
+	require.NoError(t, SweepOrphans(context.Background(), cl, cl, 5*time.Minute))
+
+	for _, kept := range []string{"configcheck-live", "configcheck-secret-assets-live"} {
 		require.NoError(t,
 			cl.Get(context.Background(), types.NamespacedName{Namespace: "vector", Name: kept}, &corev1.Secret{}),
-			"%s must survive the sweep", kept)
+			"%s belongs to a running configcheck and must survive the sweep", kept)
 	}
+}
+
+// The window is the configcheck timeout, which is operator-configurable down to zero.
+// A zero or near-zero window would sweep every running check - the very bug the window
+// exists to prevent - so it is floored.
+func TestSweepOrphansFloorsTheWindowForTinyTimeouts(t *testing.T) {
+	live := configCheckSecret("configcheck-live", time.Now().Add(-5*time.Second), true)
+
+	scheme := runtime.NewScheme()
+	require.NoError(t, corev1.AddToScheme(scheme))
+	cl := crfake.NewClientBuilder().WithScheme(scheme).WithObjects(live).Build()
+
+	require.NoError(t, SweepOrphans(context.Background(), cl, cl, 0))
+
+	require.NoError(t,
+		cl.Get(context.Background(), types.NamespacedName{Namespace: "vector", Name: "configcheck-live"}, &corev1.Secret{}),
+		"a running configcheck must survive even when the configured timeout is degenerate")
+}
+
+// A single sweep at startup can only see what is already older than the window, so
+// an orphan left behind moments before this process started would survive forever.
+// The sweeper repeats, and the orphan ages into a later pass.
+func TestRunOrphanSweeperSweepsSecretsThatAgeIntoTheWindow(t *testing.T) {
+	fresh := configCheckSecret("configcheck-just-orphaned", time.Now(), true)
+
+	scheme := runtime.NewScheme()
+	require.NoError(t, corev1.AddToScheme(scheme))
+	cl := crfake.NewClientBuilder().WithScheme(scheme).WithObjects(fresh).Build()
+
+	// Drop the floor so the whole scenario fits in a few seconds; the floor itself is
+	// covered by TestSweepOrphansFloorsTheWindowForTinyTimeouts.
+	defer func(f time.Duration) { minOrphanAge = f }(minOrphanAge)
+	minOrphanAge = 0
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	// The window is wider than the one-second resolution of metav1.Time, so the Secret
+	// is certainly too young for the first pass: only a repeated pass sweeps it. The
+	// interval is independent of the window - sweeping is a cluster-wide List, too
+	// expensive to repeat every window.
+	go RunOrphanSweeper(ctx, cl, cl, 2*time.Second, 100*time.Millisecond)
+
+	require.Never(t, func() bool {
+		err := cl.Get(ctx, types.NamespacedName{Namespace: "vector", Name: "configcheck-just-orphaned"}, &corev1.Secret{})
+		return api_errors.IsNotFound(err)
+	}, time.Second, 100*time.Millisecond, "the first pass must not touch a Secret younger than the window")
+
+	require.Eventually(t, func() bool {
+		err := cl.Get(ctx, types.NamespacedName{Namespace: "vector", Name: "configcheck-just-orphaned"}, &corev1.Secret{})
+		return api_errors.IsNotFound(err)
+	}, 15*time.Second, 100*time.Millisecond, "a Secret that ages past the window must be swept by a later pass")
 }

--- a/internal/config/configcheck/watch_test.go
+++ b/internal/config/configcheck/watch_test.go
@@ -36,19 +36,21 @@ type checkResult struct {
 }
 
 // startGetCheckResult runs getCheckResult against a fake watcher the test controls.
-// The timeout is short so a starved wait surfaces as ErrConfigcheckTimeout quickly.
-func startGetCheckResult(t *testing.T, timeout time.Duration) (*watch.FakeWatcher, *corev1.Pod, chan checkResult) {
+// The budget is short so a starved wait surfaces as ErrConfigcheckTimeout quickly.
+// The watcher is race-free: getCheckResult stops it on return, and a test that keeps
+// feeding events would otherwise send on a closed channel.
+func startGetCheckResult(t *testing.T, budget time.Duration) (*watch.RaceFreeFakeWatcher, *corev1.Pod, chan checkResult) {
 	t.Helper()
 	cs := k8sfake.NewSimpleClientset()
-	fw := watch.NewFakeWithChanSize(4, false)
+	fw := watch.NewRaceFreeFake()
 	cs.PrependWatchReactor("pods", k8stesting.DefaultWatchReactor(fw, nil))
 
-	cc := &ConfigCheck{ClientSet: cs, Namespace: "ns", ConfigCheckTimeout: timeout}
+	cc := &ConfigCheck{ClientSet: cs, Namespace: "ns", ConfigCheckTimeout: budget}
 	pod := &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Namespace: "ns", Name: "configcheck-x"}}
 
 	res := make(chan checkResult, 1)
 	go func() {
-		reason, err := cc.getCheckResult(context.Background(), pod)
+		reason, err := cc.getCheckResult(context.Background(), pod, time.Now().Add(budget))
 		res <- checkResult{reason, err}
 	}()
 	return fw, pod, res
@@ -167,5 +169,30 @@ func TestGetCheckResultTimeoutBoundsTheWholeCheck(t *testing.T) {
 	}
 	if elapsed := time.Since(start); elapsed > 4*timeout {
 		t.Fatalf("check ran for %v, the timeout must bound it at about %v", elapsed, timeout)
+	}
+}
+
+// The budget starts in Run, before the configcheck Secret is even created, and
+// getCheckResult only gets what is left of it. A deadline that already passed by the
+// time the watch is established must end the check at once - the Secret is by then as
+// old as the whole timeout, which is exactly when the orphan sweep may remove it.
+func TestGetCheckResultEndsOnAnExpiredDeadline(t *testing.T) {
+	cs := k8sfake.NewSimpleClientset()
+	fw := watch.NewRaceFreeFake()
+	defer fw.Stop()
+	cs.PrependWatchReactor("pods", k8stesting.DefaultWatchReactor(fw, nil))
+
+	cc := &ConfigCheck{ClientSet: cs, Namespace: "ns", ConfigCheckTimeout: time.Hour}
+	pod := &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Namespace: "ns", Name: "configcheck-x"}}
+
+	res := make(chan checkResult, 1)
+	go func() {
+		reason, err := cc.getCheckResult(context.Background(), pod, time.Now().Add(-time.Second))
+		res <- checkResult{reason, err}
+	}()
+
+	r := waitResult(t, res, 2*time.Second)
+	if !errors.Is(r.err, ErrConfigcheckTimeout) {
+		t.Fatalf("want ErrConfigcheckTimeout, got err=%v reason=%q", r.err, r.reason)
 	}
 }

--- a/internal/config/configcheck/watch_test.go
+++ b/internal/config/configcheck/watch_test.go
@@ -26,7 +26,9 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/watch"
+	"k8s.io/client-go/kubernetes"
 	k8sfake "k8s.io/client-go/kubernetes/fake"
+	corev1client "k8s.io/client-go/kubernetes/typed/core/v1"
 	k8stesting "k8s.io/client-go/testing"
 )
 
@@ -195,4 +197,77 @@ func TestGetCheckResultEndsOnAnExpiredDeadline(t *testing.T) {
 	if !errors.Is(r.err, ErrConfigcheckTimeout) {
 		t.Fatalf("want ErrConfigcheckTimeout, got err=%v reason=%q", r.err, r.reason)
 	}
+}
+
+// podWatchCtxRecorder captures the context Watch is called with. The fake clientset's
+// reactors never see that context, and what matters here is exactly that the request
+// establishing the watch carries the check budget: a hung request would otherwise sit
+// outside both the budget context and the timer.
+type podWatchCtxRecorder struct {
+	kubernetes.Interface
+	got chan context.Context
+}
+
+func (r *podWatchCtxRecorder) CoreV1() corev1client.CoreV1Interface {
+	return &recordingCoreV1{r.Interface.CoreV1(), r}
+}
+
+type recordingCoreV1 struct {
+	corev1client.CoreV1Interface
+	rec *podWatchCtxRecorder
+}
+
+func (c *recordingCoreV1) Pods(namespace string) corev1client.PodInterface {
+	return &recordingPods{c.CoreV1Interface.Pods(namespace), c.rec}
+}
+
+type recordingPods struct {
+	corev1client.PodInterface
+	rec *podWatchCtxRecorder
+}
+
+func (p *recordingPods) Watch(ctx context.Context, opts metav1.ListOptions) (watch.Interface, error) {
+	select {
+	case p.rec.got <- ctx:
+	default:
+	}
+	return p.PodInterface.Watch(ctx, opts)
+}
+
+// Establishing the watch is an HTTP request of its own, and it must be bounded by the
+// same budget as the rest of the check: if it hangs, neither the timer (not created
+// yet) nor the caller's ctx would end it.
+func TestGetCheckResultBoundsTheWatchRequestByTheBudget(t *testing.T) {
+	cs := k8sfake.NewSimpleClientset()
+	fw := watch.NewRaceFreeFake()
+	defer fw.Stop()
+	cs.PrependWatchReactor("pods", k8stesting.DefaultWatchReactor(fw, nil))
+	rec := &podWatchCtxRecorder{Interface: cs, got: make(chan context.Context, 1)}
+
+	cc := &ConfigCheck{ClientSet: rec, Namespace: "ns", ConfigCheckTimeout: time.Hour}
+	pod := &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Namespace: "ns", Name: "configcheck-x"}}
+	deadline := time.Now().Add(300 * time.Millisecond)
+
+	res := make(chan checkResult, 1)
+	go func() {
+		reason, err := cc.getCheckResult(context.Background(), pod, deadline)
+		res <- checkResult{reason, err}
+	}()
+
+	var watchCtx context.Context
+	select {
+	case watchCtx = <-rec.got:
+	case <-time.After(2 * time.Second):
+		t.Fatal("Watch was never called")
+	}
+
+	got, ok := watchCtx.Deadline()
+	if !ok {
+		t.Fatal("the request establishing the watch must carry the check budget")
+	}
+	if got.After(deadline.Add(50 * time.Millisecond)) {
+		t.Fatalf("watch deadline %v runs past the check budget %v", got, deadline)
+	}
+
+	waitResult(t, res, 3*time.Second)
 }

--- a/internal/config/configcheck/watch_test.go
+++ b/internal/config/configcheck/watch_test.go
@@ -133,3 +133,39 @@ func TestGetCheckResultErrsOnClosedWatchChannel(t *testing.T) {
 		t.Fatalf("want error on closed watch, got success (reason=%q)", r.reason)
 	}
 }
+
+// ConfigCheckTimeout must bound the whole check, not the gap between pod events.
+// A pod that keeps emitting status updates - image pull progress, repeated scheduling
+// attempts - would otherwise extend the check indefinitely: it holds the reconcile
+// worker, and it outlives the age window the orphan sweep relies on to tell a running
+// check from a leftover.
+func TestGetCheckResultTimeoutBoundsTheWholeCheck(t *testing.T) {
+	const timeout = 300 * time.Millisecond
+	fw, pod, res := startGetCheckResult(t, timeout)
+
+	stop := make(chan struct{})
+	defer close(stop)
+	go func() {
+		tick := time.NewTicker(timeout / 6)
+		defer tick.Stop()
+		for {
+			select {
+			case <-stop:
+				return
+			case <-tick.C:
+				pending := pod.DeepCopy()
+				pending.Status.Phase = corev1.PodPending
+				fw.Modify(pending)
+			}
+		}
+	}()
+
+	start := time.Now()
+	r := waitResult(t, res, 3*time.Second)
+	if !errors.Is(r.err, ErrConfigcheckTimeout) {
+		t.Fatalf("want ErrConfigcheckTimeout, got err=%v reason=%q", r.err, r.reason)
+	}
+	if elapsed := time.Since(start); elapsed > 4*timeout {
+		t.Fatalf("check ran for %v, the timeout must bound it at about %v", elapsed, timeout)
+	}
+}


### PR DESCRIPTION
## Problem

Before rolling out a config, the operator validates it in a temporary pod. The config for that pod lives in a temporary Secret, and nothing owns that Secret, so a crashed operator leaves it behind. #278 added a sweep for those leftovers: on startup, every such Secret created before the process started is treated as an orphan and deleted.

That rule breaks during an upgrade. Kubernetes starts the new operator pod before the old one stops, so for a few seconds two processes are running. The new one deletes the Secret of a check the old one is still doing. The check pod goes away with the Secret, the old process reports `pod ... was deleted before producing a result`, and the pipeline is marked invalid. Nobody retries it: the next reconcile sees an unchanged spec and skips the pipeline, so it stays invalid and its sources drop out of the agent config until someone touches it.

#278 has not shipped in a release yet, so no user has hit this.

## Fix

A check can never run longer than its own timeout, so age is the honest test for an orphan. The sweep now deletes only Secrets older than the configcheck timeout; anything younger belongs to a check that is still running, no matter which process started it.

That holds only if the timeout really bounds the check, and it did not: the timer restarted on every pod event, and it covered just the wait for the result. It is now a single budget for the whole check - the calls that create the Secret and the pod, the request that establishes the watch, and the wait - and it starts before the Secret exists. A cluster where a check legitimately needs longer should raise `--configcheck-timeout`.

Two smaller things come with it. The window never shrinks below a minute, since the timeout is a flag and can be set to zero. And the sweep repeats hourly instead of running once at startup, because a Secret orphaned just before startup is too young for the first pass and nothing would look at it again.

## Verification

Unit tests cover every rule, each checked by breaking the code and watching the matching test fail. Checked live as well: the old code loses a pipeline when the operator restarts mid-check, the new code does not, orphans left by a killed process are still swept, and a normal check still passes and reaches the agent config.
