### PR TITLE
fix: treat a cancelled configcheck as an error, not a passing check

### DIFF
--- a/internal/config/configcheck/configcheck.go
+++ b/internal/config/configcheck/configcheck.go
@@ -365,7 +365,10 @@ func (cc *ConfigCheck) getCheckResult(ctx context.Context, pod *corev1.Pod, dead
 				return "", fmt.Errorf("configcheck: pod %s was deleted before producing a result", pod.Name)
 			}
 		case <-ctx.Done():
-			return "", nil
+			// The caller gave up - shutdown, a cancelled reconcile. Reporting no error
+			// here reads as a passing check, and the reconciler publishes a config that
+			// was never validated.
+			return "", fmt.Errorf("configcheck: %w while waiting for pod %s", ctx.Err(), pod.Name)
 		case <-timer.C:
 			return "", ErrConfigcheckTimeout
 		}

--- a/internal/config/configcheck/watch_test.go
+++ b/internal/config/configcheck/watch_test.go
@@ -271,3 +271,34 @@ func TestGetCheckResultBoundsTheWatchRequestByTheBudget(t *testing.T) {
 
 	waitResult(t, res, 3*time.Second)
 }
+
+// A cancelled context means the caller gave up, not that the config is valid.
+// getCheckResult used to return ("", nil) there, which the pipeline reconciler reads
+// as a passing check and turns into a success status - a config that was never
+// validated would be published as validated.
+func TestGetCheckResultDoesNotReportSuccessOnCancellation(t *testing.T) {
+	cs := k8sfake.NewSimpleClientset()
+	fw := watch.NewRaceFreeFake()
+	defer fw.Stop()
+	cs.PrependWatchReactor("pods", k8stesting.DefaultWatchReactor(fw, nil))
+
+	cc := &ConfigCheck{ClientSet: cs, Namespace: "ns", ConfigCheckTimeout: time.Hour}
+	pod := &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Namespace: "ns", Name: "configcheck-x"}}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	res := make(chan checkResult, 1)
+	go func() {
+		reason, err := cc.getCheckResult(ctx, pod, time.Now().Add(time.Hour))
+		res <- checkResult{reason, err}
+	}()
+
+	cancel()
+
+	r := waitResult(t, res, 2*time.Second)
+	if r.err == nil {
+		t.Fatalf("a cancelled check must not look like a passing one, got reason=%q err=nil", r.reason)
+	}
+	if !errors.Is(r.err, context.Canceled) {
+		t.Fatalf("want an error carrying context.Canceled, got %v", r.err)
+	}
+}


### PR DESCRIPTION
## Problem

While waiting for a configcheck result, a cancelled context is reported as no error at all. The pipeline reconciler reads that as a passing check and writes a success status, so a config that was never validated is published as validated.

## Fix

Return the cancellation as an error instead. A check interrupted by a shutdown now ends with an error in the log rather than a silent pass.

## Verification

A unit test cancels the context while the check is waiting and requires an error carrying `context.Canceled`; it was checked by putting the old `return "", nil` back and watching the test fail.
