### PR TITLE
docs: describe what --watch-name actually filters on

### DIFF
--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -101,7 +101,7 @@ func main() {
 	flag.BoolVar(&enableHTTP2, "enable-http2", false,
 		"If set, HTTP/2 will be enabled for the metrics and webhook servers")
 	flag.StringVar(&watchNamespace, "watch-namespace", "", "Namespace to filter the list of watched objects")
-	flag.StringVar(&watchLabel, "watch-name", "", "Filter the list of watched objects by checking the app.kubernetes.io/managed-by label")
+	flag.StringVar(&watchLabel, "watch-name", "", "Filter the list of watched objects by the value of their app.kubernetes.io/name label; they must also carry app.kubernetes.io/managed-by=vector-operator")
 	flag.DurationVar(&configCheckTimeout, "configcheck-timeout", 300*time.Second, "configcheck timeout")
 	flag.BoolVar(&enableReconciliationInvalidPipelines, "enable-reconciliation-invalid-pipelines", false,
 		"Enable the reconciliation process for pipelines with invalid configurations")

--- a/helm/charts/vector-operator/values.yaml
+++ b/helm/charts/vector-operator/values.yaml
@@ -69,7 +69,7 @@ annotations: {}
 # Args to path to operator
 args:
 #  - "-watch-namespace=vector" # Namespace to filter the list of watched objects
-#  - "-watch-name=vector-operator" # Filter the list of watched objects by checking the app.kubernetes.io/managed-by label
+#  - "-watch-name=vector-operator" # Filter the list of watched objects by the value of their app.kubernetes.io/name label; they must also carry app.kubernetes.io/managed-by=vector-operator
 #  - "-enable-reconciliation-invalid-pipelines=true" # Enable the reconciliation process for pipelines with invalid configurations
 #  - "-reconciliation-retry-delay=120s" # Specify the delay before retrying the reconciliation process for pipelines
 #  - "-enable-config-optimization" # Collapse kubernetes_logs sources with identical settings into one source per group (opt out per Vector CR or per (Cluster)VectorPipeline with the vector-operator.kaasops.io/config-optimization=disabled annotation)


### PR DESCRIPTION
`--watch-name` says it filters on `app.kubernetes.io/managed-by`, but the selector matches the flag's value against `app.kubernetes.io/name` and requires `managed-by=vector-operator` on top. The chart's `values.yaml` repeats the same sentence, so both are corrected.
